### PR TITLE
Tweaked documentation for logger upload functions

### DIFF
--- a/R/html_processing.R
+++ b/R/html_processing.R
@@ -3,7 +3,7 @@
 #' @description Parse YOWN html logger files, upload to Aquarius, sort into respective folder, and track logger metadata. Used "Pressure" column after converting to m water column. If pressure column does not exist, converts from deth using formula supplied by In Situ
 #'
 #' @param file Full path to the .html file. This must be an html file from an In Situ logger.
-#' @param aq_upload Logical, whether to upload data to Aquarius. If FALSE a data.frame of the data is returned.
+#' @param aq_upload Logical, whether to upload data to Aquarius. If FALSE a data.frame of the data is returned. Uses function [aq_upload()] with default parameters, so you'll want to make sure your Aquarius login details are in your .Renviron file.
 #' @param master_sheet Path to YOWN master sheet (.xlsx), used to match logger data to YOWN ID and ensure integrity.
 #' @param logger_tracking Path to YOWN logger tracking sheet (.xlsx), used to track logger metadata. This part is done within a tryCatch block to enable this function to run even if the logger tracking sheet is open, missing, or otherwise inaccessible.
 #' @param dropbox Path to YOWN logger dropbox folder, where the html file is located. This is used to move the file to the appropriate folder after processing.

--- a/R/xle_processing.R
+++ b/R/xle_processing.R
@@ -4,7 +4,7 @@
 #' Parse xle (Solinst) logger files, upload to Aquarius, sort into respective folder, and track logger metadata. Created to work within the Yukon Water Resources Branch's folder structure.
 #'
 #' @param file Full path to the .xle file. This must be an XLE file from a Solinst logger.
-#' @param aq_upload Logical, whether to upload data to Aquarius. If FALSE a data.frame of the data is returned.
+#' @param aq_upload Logical, whether to upload data to Aquarius. If FALSE a data.frame of the data is returned. Uses function [aq_upload()] with default parameters, so you'll want to make sure your Aquarius login details are in your .Renviron file.
 #' @param master_sheet Path to YOWN master sheet (.xlsx), used to match logger data to YOWN ID and ensure integrity.
 #' @param logger_tracking Path to YOWN logger tracking sheet (.xlsx), used to track logger metadata. This part is done within a tryCatch block to enable this function to run even if the logger tracking sheet is open, missing, or otherwise inaccessible.
 #' @param dropbox Path to YOWN logger dropbox folder, where the xle file is located. This is used to move the file to the appropriate folder after processing.

--- a/man/html_processing.Rd
+++ b/man/html_processing.Rd
@@ -20,7 +20,7 @@ html_processing(
 \arguments{
 \item{file}{Full path to the .html file. This must be an html file from an In Situ logger.}
 
-\item{aq_upload}{Logical, whether to upload data to Aquarius. If FALSE a data.frame of the data is returned.}
+\item{aq_upload}{Logical, whether to upload data to Aquarius. If FALSE a data.frame of the data is returned. Uses function \code{\link[=aq_upload]{aq_upload()}} with default parameters, so you'll want to make sure your Aquarius login details are in your .Renviron file.}
 
 \item{master_sheet}{Path to YOWN master sheet (.xlsx), used to match logger data to YOWN ID and ensure integrity.}
 

--- a/man/xle_processing.Rd
+++ b/man/xle_processing.Rd
@@ -20,7 +20,7 @@ xle_processing(
 \arguments{
 \item{file}{Full path to the .xle file. This must be an XLE file from a Solinst logger.}
 
-\item{aq_upload}{Logical, whether to upload data to Aquarius. If FALSE a data.frame of the data is returned.}
+\item{aq_upload}{Logical, whether to upload data to Aquarius. If FALSE a data.frame of the data is returned. Uses function \code{\link[=aq_upload]{aq_upload()}} with default parameters, so you'll want to make sure your Aquarius login details are in your .Renviron file.}
 
 \item{master_sheet}{Path to YOWN master sheet (.xlsx), used to match logger data to YOWN ID and ensure integrity.}
 


### PR DESCRIPTION
Copying you for a review since you wrote these! As written before there was no way for the user to know they need parameters in their .Renviron file. An even more flexible way to do it would be to add parameters to the two _processing functions that get passed to aq_upload, giving the option of bypassing the .Renviron file entirely.