### PR TITLE
Fix param filter intersection

### DIFF
--- a/inst/apps/YGwater/modules/client/data/continuousData.R
+++ b/inst/apps/YGwater/modules/client/data/continuousData.R
@@ -468,13 +468,12 @@ contData <- function(id, language) {
       # Filter the parameters based on the selected groups and sub-groups, update the params selectizeInput
       req(input$pGrps, input$pSubGrps, filteredData$parameter_relationships, filteredData$params)
       
+      remain_params <- filteredData$parameter_relationships
       if (!("all" %in% input$pGrps)) {
-        remain_params <- filteredData$parameter_relationships[filteredData$parameter_relationships$group_id %in% input$pGrps, ]
-      } else {
-        remain_params <- filteredData$parameter_relationships
+        remain_params <- remain_params[remain_params$group_id %in% input$pGrps, ]
       }
       if (!("all" %in% input$pSubGrps)) {
-        remain_params <- filteredData$parameter_relationships[filteredData$parameter_relationships$sub_group_id %in% input$pSubGrps, ]
+        remain_params <- remain_params[remain_params$sub_group_id %in% input$pSubGrps, ]
       }
       remain_params <- filteredData$params[filteredData$params$parameter_id %in% remain_params$parameter_id, ]
       updateSelectizeInput(session, "params",

--- a/inst/apps/YGwater/modules/client/data/discreteData.R
+++ b/inst/apps/YGwater/modules/client/data/discreteData.R
@@ -406,13 +406,12 @@ discData <- function(id, language) {
       # Filter the parameters based on the selected groups and sub-groups, update the params selectizeInput
       req(input$pGrps, input$pSubGrps, filteredData$parameter_relationships, filteredData$params)
       
+      remain_params <- filteredData$parameter_relationships
       if (!("all" %in% input$pGrps)) {
-        remain_params <- filteredData$parameter_relationships[filteredData$parameter_relationships$group_id %in% input$pGrps, ]
-      } else {
-        remain_params <- filteredData$parameter_relationships
+        remain_params <- remain_params[remain_params$group_id %in% input$pGrps, ]
       }
       if (!("all" %in% input$pSubGrps)) {
-        remain_params <- filteredData$parameter_relationships[filteredData$parameter_relationships$sub_group_id %in% input$pSubGrps, ]
+        remain_params <- remain_params[remain_params$sub_group_id %in% input$pSubGrps, ]
       }
       remain_params <- filteredData$params[filteredData$params$parameter_id %in% remain_params$parameter_id, ]
       updateSelectizeInput(session, "params",


### PR DESCRIPTION
## Summary
- fix param filtering logic for continuous data
- fix param filtering logic for discrete data

## Testing
- `R CMD build .` *(fails: `R` not found)*