### PR TITLE
Fix map popup links to match available data types

### DIFF
--- a/inst/apps/YGwater/modules/client/map/locations.R
+++ b/inst/apps/YGwater/modules/client/map/locations.R
@@ -301,18 +301,48 @@ mapLocs <- function(id, language) {
       tmp[location_parameters, on = .(location_id), parameters := parameters]  # Join location_parameters
       tmp[location_networks, on = .(location_id), networks := networks]  # Join location_networks
       tmp[location_projects, on = .(location_id), projects := projects]  # Join location_projects
-      
+
+      # Determine available data types for each location
+      loc_data_types <- moduleData$timeseries[, .(
+        has_discrete = any(data_type == "discrete"),
+        has_continuous = any(data_type == "continuous")
+      ), by = location_id]
+      tmp[loc_data_types, on = .(location_id), `:=`(has_discrete = i.has_discrete,
+                                                    has_continuous = i.has_continuous)]
+
+      tmp[, popup_links := {
+        links <- character(0)
+        if (isTRUE(has_discrete)) {
+          links <- c(links,
+            sprintf("<a href='#' onclick='changeTab(\"mapLocs-\", \"clicked_dl_data_discrete\", \"%s\"); return false;'>%s</a>",
+                    location_id, tr("dl_data_discrete", language$language)),
+            sprintf("<a href='#' onclick='changeTab(\"mapLocs-\", \"clicked_view_plots_discrete\", \"%s\"); return false;'>%s</a>",
+                    location_id, tr("view_plots_discrete", language$language))
+          )
+        }
+        if (isTRUE(has_continuous)) {
+          links <- c(links,
+            sprintf("<a href='#' onclick='changeTab(\"mapLocs-\", \"clicked_dl_data_continuous\", \"%s\"); return false;'>%s</a>",
+                    location_id, tr("dl_data_continuous", language$language)),
+            sprintf("<a href='#' onclick='changeTab(\"mapLocs-\", \"clicked_view_plots_continuous\", \"%s\"); return false;'>%s</a>",
+                    location_id, tr("view_plots_continuous", language$language))
+          )
+        }
+        if (length(links) > 0) {
+          paste0("<br/>", paste(links, collapse = "<br/>"), "<br/>")
+        } else {
+          ""
+        }
+      }]
+
       tmp[, popup_html := paste0(
         "<strong>", popup_name, "</strong><br/>",
         substr(start_time, 1, 10), " ", tr("to", language$language), " ", substr(end_time, 1, 10), "<br/><br/>",
         "<strong>", tr("parameter(s)", language$language), ":</strong><br/>",
         "<div style='max-height:100px; overflow-y:auto;'><i>", parameters, "</i></div><br/>",  # Supposed to be scrollable
         "<strong>", tr("network(s)", language$language), ":</strong><br/><i>", networks, "</i><br/>",
-        "<strong>", tr("project(s)", language$language), ":</strong><br/><i>", ifelse(is.na(projects), "N/A", paste(projects, collapse = "<br/>")), "</i><br/>",
-        "<br/><a href='#' onclick='changeTab(\"mapLocs-\", \"clicked_dl_data_discrete\", \"", location_id, "\"); return false;'>", tr("dl_data_discrete", language$language), "</a><br/>",
-        "<a href='#' onclick='changeTab(\"mapLocs-\", \"clicked_dl_data_continuous\", \"", location_id, "\"); return false;'>", tr("dl_data_continuous", language$language), "</a><br/>",
-        "<a href='#' onclick='changeTab(\"mapLocs-\", \"clicked_view_plots_discrete\", \"", location_id, "\"); return false;'>", tr("view_plots_discrete", language$language), "</a><br/>",
-        "<a href='#' onclick='changeTab(\"mapLocs-\", \"clicked_view_plots_continuous\", \"", location_id, "\"); return false;'>", tr("view_plots_continuous", language$language), "</a><br/>"
+        "<strong>", tr("project(s)", language$language), ":</strong><br/><i>", ifelse(is.na(projects), "N/A", paste(projects, collapse = "<br/>")), "</i>",
+        popup_links
       )]
       
       tmp


### PR DESCRIPTION
## Summary
- update locations map popup generation
- show download/plot links only for data types available at each location

## Testing
- `devtools::test()` *(fails: `R: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_683a78dac02c832f917b8f1e9d0717cd