### PR TITLE
Add navigation buttons on home page

### DIFF
--- a/inst/apps/YGwater/modules/client/info/home.R
+++ b/inst/apps/YGwater/modules/client/info/home.R
@@ -9,6 +9,26 @@ homeUI <- function(id) {
     htmlOutput(ns("title")),
     tags$div(style = "height: 10px;"),
     htmlOutput(ns("text")),
+    tags$div(style = "height: 20px;"),
+    htmlOutput(ns("buttonsTitle")),
+    tags$div(style = "height: 10px;"),
+    fluidRow(
+      column(4, actionButton(ns("plot_disc"), "Plot discrete data",
+                             class = "btn btn-primary w-100")),
+      column(4, actionButton(ns("plot_cont"), "Plot continuous data",
+                             class = "btn btn-primary w-100")),
+      column(4, actionButton(ns("dl_disc"), "Download discrete data",
+                             class = "btn btn-primary w-100"))
+    ),
+    tags$div(style = "height: 10px;"),
+    fluidRow(
+      column(4, actionButton(ns("dl_cont"), "Download continuous data",
+                             class = "btn btn-primary w-100")),
+      column(4, actionButton(ns("map_locs"), "Monitoring locations map",
+                             class = "btn btn-primary w-100")),
+      column(4, actionButton(ns("map_params"), "Parameter values map",
+                             class = "btn btn-primary w-100"))
+    ),
     tags$div(style = "height: 40px;"),
     htmlOutput(ns("discTitle")),
     tags$div(style = "height: 10px;"),
@@ -18,9 +38,11 @@ homeUI <- function(id) {
 
 home <- function(id, language) {
   moduleServer(id, function(input, output, session) {
-    
+
     ns <- session$ns
-    
+
+    outputs <- reactiveValues()
+
     observe({
       req(language$language)
       output$betaTitle <- renderUI({
@@ -47,6 +69,12 @@ home <- function(id, language) {
                     '</div>'
         ))
       })
+      output$buttonsTitle <- renderUI({
+        HTML(paste0('<div class="nunito-sans" style="font-size: 16px; font-weight: 500;">',
+                    'Select an option below to explore the data:',
+                    '</div>'
+        ))
+      })
       output$discTitle <- renderUI({
         HTML(paste0('<div class="montserrat" style="font-size: 20px; font-weight: 600; font-style: normal">',
                     tr("disclaimer_title", language$language),
@@ -60,5 +88,26 @@ home <- function(id, language) {
         ))
       })
     })
+
+    observeEvent(input$plot_disc, {
+      outputs$change_tab <- "discrete"
+    })
+    observeEvent(input$plot_cont, {
+      outputs$change_tab <- "continuous"
+    })
+    observeEvent(input$dl_disc, {
+      outputs$change_tab <- "discData"
+    })
+    observeEvent(input$dl_cont, {
+      outputs$change_tab <- "contData"
+    })
+    observeEvent(input$map_locs, {
+      outputs$change_tab <- "monitoringLocations"
+    })
+    observeEvent(input$map_params, {
+      outputs$change_tab <- "parameterValues"
+    })
+
+    return(outputs)
   })
 }

--- a/inst/apps/YGwater/server.R
+++ b/inst/apps/YGwater/server.R
@@ -478,8 +478,15 @@ $(document).keyup(function(event) {
       if (!ui_loaded$home) {
         output$home_ui <- renderUI(homeUI("home"))
         ui_loaded$home <- TRUE
-        home("home", language = languageSelection) # Call the server
+        moduleOutputs$home <- home("home", language = languageSelection) # Call the server
       }
+      observe({
+        if (!is.null(moduleOutputs$home$change_tab)) {
+          target <- moduleOutputs$home$change_tab
+          nav_select(session = session, "navbar", selected = target)
+          moduleOutputs$home$change_tab <- NULL
+        }
+      })
     }
     
     ### Plots nav_menu ##########################


### PR DESCRIPTION
## Summary
- add navigation buttons and instructions on the home page module
- return button events from the home module server
- react to home page navigation events in the main server

## Testing
- `R -q -e "devtools::test()"` *(fails: `R` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_683bdf735dc4832fa80e772b5851f8a2