### PR TITLE
Fix webGL plotting on Android

### DIFF
--- a/R/plotMultiTimeseries.R
+++ b/R/plotMultiTimeseries.R
@@ -34,6 +34,8 @@
 #' @param legend_position The position of the legend, 'v' for vertical on the right side or 'h' for horizontal on the bottom. Default is 'v'. If 'h', slider will be set to FALSE due to interference.
 #' @param gridx Should gridlines be drawn on the x-axis? Default is FALSE
 #' @param gridy Should gridlines be drawn on the y-axis? Default is FALSE
+#' @param webgl Use WebGL ("scattergl") for faster rendering when possible. Set
+#'   to FALSE to force standard scatter traces.
 #' @param rate The rate at which to plot the data. Default is NULL, which will adjust for reasonable plot performance depending on the date range. Otherwise set to one of "max", "hour", "day".
 #' @param tzone The timezone to use for the plot. Default is "auto", which will use the system default timezone. Otherwise set to a valid timezone string.
 #' @param data Should the data used to create the plot be returned? Default is FALSE.
@@ -72,6 +74,7 @@ plotMultiTimeseries <- function(type = 'traces',
                                 legend_position = 'v',
                                 gridx = FALSE,
                                 gridy = FALSE,
+                                webgl = TRUE,
                                 rate = NULL,
                                 tzone = "auto",
                                 data = FALSE,
@@ -876,7 +879,7 @@ plotMultiTimeseries <- function(type = 'traces',
           data = data.sub, 
           x = ~datetime, 
           y = ~value, 
-          type = "scattergl", 
+          type = if (webgl) "scattergl" else "scatter", 
           mode = "lines",
           line = list(width = 2.5 * line_scale),
           name = timeseries[i, "trace_title"], 
@@ -992,7 +995,7 @@ plotMultiTimeseries <- function(type = 'traces',
         plotly::add_trace(data = data[[i]]$trace_data, 
                           x = ~datetime, 
                           y = ~value, 
-                          type = "scattergl", 
+                          type = if (webgl) "scattergl" else "scatter", 
                           mode = "lines",
                           line = list(width = 2.5 * line_scale),
                           name = parameter_name, 

--- a/R/plotOverlap.R
+++ b/R/plotOverlap.R
@@ -32,6 +32,8 @@
 #' @param hover Should hover text be included? Default is TRUE.
 #' @param gridx Should grid lines be drawn on the x-axis? Default is FALSE
 #' @param gridy Should grid lines be drawn on the y-axis? Default is FALSE
+#' @param webgl Use WebGL ("scattergl") for faster rendering when possible. Set
+#'   to FALSE to force standard scatter traces.
 #' @param lang The language to use for the plot. Currently only "en" and "fr" are supported. Default is "en".
 #' @param data Should the data used to create the plot be returned? Default is FALSE.
 #' @param con A connection to the target database. NULL uses AquaConnect from this package and automatically disconnects.
@@ -97,6 +99,7 @@ plotOverlap <- function(location,
                         hover = TRUE,
                         gridx = FALSE,
                         gridy = TRUE,
+                        webgl = TRUE,
                         lang = "en",
                         data = FALSE,
                         con = NULL)
@@ -730,7 +733,7 @@ plotOverlap <- function(location,
                               x = ~plot_datetime,
                               y = ~value,
                               # type = "scatter",
-                              type = "scattergl",
+                              type = if (webgl) "scattergl" else "scatter",
                               mode = "lines",
                               line = list(width = 2.5 * line_scale),
                               name = i,

--- a/R/plotTimeseries.R
+++ b/R/plotTimeseries.R
@@ -33,6 +33,8 @@
 #' @param hover Should hover text be included? Default is TRUE.
 #' @param gridx Should gridlines be drawn on the x-axis? Default is FALSE
 #' @param gridy Should gridlines be drawn on the y-axis? Default is FALSE
+#' @param webgl Use WebGL ("scattergl") for faster rendering when possible. Set
+#'   to FALSE to force standard scatter traces.
 #' @param rate The rate at which to plot the data. Default is NULL, which will adjust for reasonable plot performance depending on the date range. Otherwise set to one of "max", "hour", "day".
 #' @param tzone The timezone to use for the plot. Default is "auto", which will use the system default timezone. Otherwise set to a valid timezone string.
 #' @param data Should the data used to create the plot be returned? Default is FALSE.
@@ -70,6 +72,7 @@ plotTimeseries <- function(location,
                            hover = TRUE,
                            gridx = FALSE,
                            gridy = FALSE,
+                           webgl = TRUE,
                            rate = NULL,
                            tzone = "auto",
                            data = FALSE,
@@ -640,7 +643,7 @@ plotTimeseries <- function(location,
     plotly::add_trace(data = trace_data, 
                       x = ~datetime, 
                       y = ~value, 
-                      type = "scattergl", 
+                      type = if (webgl) "scattergl" else "scatter", 
                       mode = "lines",
                       line = list(width = 2.5 * line_scale),
                       name = parameter_name, 

--- a/inst/apps/YGwater/modules/client/plot/continuousPlot.R
+++ b/inst/apps/YGwater/modules/client/plot/continuousPlot.R
@@ -2366,7 +2366,7 @@ continuousPlot <- function(id, language, windowDims, inputs) {
     
     # Create ExtendedTasks to render plots ############################################################
     # Overlapping years plot
-    plot_output_overlap <- ExtendedTask$new(function(loc, sub_loc, record_rate, aggregation_type, z, param, date_start, date_end, yrs, historic_range, apply_datum, filter, unusable, line_scale, axis_scale, legend_scale, legend_position, lang, gridx, gridy, config) {
+    plot_output_overlap <- ExtendedTask$new(function(loc, sub_loc, record_rate, aggregation_type, z, param, date_start, date_end, yrs, historic_range, apply_datum, filter, unusable, line_scale, axis_scale, legend_scale, legend_position, lang, gridx, gridy, webgl, config) {
       promises::future_promise({
         tryCatch({
           con <- AquaConnect(name = config$dbName,
@@ -2378,7 +2378,7 @@ continuousPlot <- function(id, language, windowDims, inputs) {
           on.exit(DBI::dbDisconnect(con))
           
           plot <- plotOverlap(location = loc,
-                              sub_location = sub_loc,
+                                                            sub_location = sub_loc,
                               z = z,
                               record_rate = record_rate,
                               aggregation_type = aggregation_type,
@@ -2395,8 +2395,8 @@ continuousPlot <- function(id, language, windowDims, inputs) {
                               axis_scale = axis_scale,
                               legend_scale = legend_scale,
                               legend_position = legend_position,
+                                      webgl = webgl,
                               slider = FALSE,
-                              lang = lang,
                               gridx = gridx,
                               gridy = gridy,
                               con = con,
@@ -2412,7 +2412,7 @@ continuousPlot <- function(id, language, windowDims, inputs) {
     
     
     # Single timeseries plot
-    plot_output_timeseries <- ExtendedTask$new(function(loc, sub_loc, record_rate, aggregation_type, z, param, date_start, date_end, historic_range, apply_datum, filter, unusable, grades, approvals, qualifiers, line_scale, axis_scale, legend_scale, legend_position, lang, gridx, gridy, config) {
+    plot_output_timeseries <- ExtendedTask$new(function(loc, sub_loc, record_rate, aggregation_type, z, param, date_start, date_end, historic_range, apply_datum, filter, unusable, grades, approvals, qualifiers, line_scale, axis_scale, legend_scale, legend_position, lang, gridx, gridy, webgl, config) {
       promises::future_promise({
         tryCatch({
           con <- AquaConnect(name = config$dbName, 
@@ -2443,6 +2443,7 @@ continuousPlot <- function(id, language, windowDims, inputs) {
                                  axis_scale = axis_scale,
                                  legend_scale = legend_scale,
                                  legend_position = legend_position,
+                                   webgl = webgl,
                                  slider = FALSE,
                                  gridx = gridx,
                                  gridy = gridy,
@@ -2458,7 +2459,7 @@ continuousPlot <- function(id, language, windowDims, inputs) {
     ) |> bind_task_button("make_plot")
     
     # Multiple traces plot
-    plot_output_timeseries_traces <- ExtendedTask$new(function(locs, sub_locs, z, record_rates, aggregation_types, params, lead_lags, date_start, date_end, historic_range, apply_datum, filter, unusable, line_scale, axis_scale, legend_scale, legend_position, lang, gridx, gridy, shareX, shareY, config) {
+    plot_output_timeseries_traces <- ExtendedTask$new(function(locs, sub_locs, z, record_rates, aggregation_types, params, lead_lags, date_start, date_end, historic_range, apply_datum, filter, unusable, line_scale, axis_scale, legend_scale, legend_position, lang, gridx, gridy, shareX, shareY, webgl, config) {
       promises::future_promise({
         tryCatch({
           con <- AquaConnect(name = config$dbName, 
@@ -2488,6 +2489,7 @@ continuousPlot <- function(id, language, windowDims, inputs) {
                                       axis_scale = axis_scale,
                                       legend_scale = legend_scale,
                                       legend_position = legend_position,
+                                        webgl = webgl,
                                       gridx = gridx,
                                       gridy = gridy,
                                       shareX = shareX,
@@ -2504,7 +2506,7 @@ continuousPlot <- function(id, language, windowDims, inputs) {
     ) |> bind_task_button("make_plot")
     
     # Multiple subplots plot
-    plot_output_timeseries_subplots <- ExtendedTask$new(function(locs, sub_locs, z, record_rates, aggregation_types, params, date_start, date_end, historic_range, apply_datum, filter, unusable, line_scale, axis_scale, legend_scale, legend_position, lang, gridx, gridy, shareX, shareY, config) {
+    plot_output_timeseries_subplots <- ExtendedTask$new(function(locs, sub_locs, z, record_rates, aggregation_types, params, date_start, date_end, historic_range, apply_datum, filter, unusable, line_scale, axis_scale, legend_scale, legend_position, lang, gridx, gridy, shareX, shareY, webgl, config) {
       promises::future_promise({
         tryCatch({
           con <- AquaConnect(name = config$dbName, 
@@ -2533,6 +2535,7 @@ continuousPlot <- function(id, language, windowDims, inputs) {
                                       axis_scale = axis_scale,
                                       legend_scale = legend_scale,
                                       legend_position = legend_position,
+                                        webgl = webgl,
                                       gridx = gridx,
                                       gridy = gridy,
                                       shareX = shareX,
@@ -2610,6 +2613,7 @@ continuousPlot <- function(id, language, windowDims, inputs) {
                                    lang = plot_aes$lang, 
                                    gridx = plot_aes$showgridx, 
                                    gridy = plot_aes$showgridy, 
+                                   webgl = session$userData$use_webgl,
                                    config = session$userData$config)
       } else if (input$plot_type == "ts") {
         if (traceCount() == 1) { # Either a single trace or more than 1 subplot
@@ -2653,6 +2657,7 @@ continuousPlot <- function(id, language, windowDims, inputs) {
                                                    lang = plot_aes$lang, 
                                                    gridx = plot_aes$showgridx, 
                                                    gridy = plot_aes$showgridy, 
+                                   webgl = session$userData$use_webgl,
                                                    shareX = input$shareX, 
                                                    shareY = input$shareY, 
                                                    config = session$userData$config)
@@ -2711,6 +2716,7 @@ continuousPlot <- function(id, language, windowDims, inputs) {
                                           lang = plot_aes$lang, 
                                           gridx = plot_aes$showgridx, 
                                           gridy = plot_aes$showgridy, 
+                                   webgl = session$userData$use_webgl,
                                           config = session$userData$config)
           }
         } else { # Multiple traces, single plot
@@ -2755,6 +2761,7 @@ continuousPlot <- function(id, language, windowDims, inputs) {
                                                lang = plot_aes$lang, 
                                                gridx = plot_aes$showgridx, 
                                                gridy = plot_aes$showgridy, 
+                                   webgl = session$userData$use_webgl,
                                                shareX = input$shareX, 
                                                shareY = input$shareY, 
                                                config = session$userData$config)

--- a/inst/apps/YGwater/server.R
+++ b/inst/apps/YGwater/server.R
@@ -168,6 +168,8 @@ app_server <- function(input, output, session) {
                                             silent = TRUE)
   
   print("Connected to AquaCache")
+
+  session$userData$use_webgl <- !grepl('Android', session$request$HTTP_USER_AGENT, ignore.case = TRUE)
   
   session$onUnhandledError(function() {
     DBI::dbDisconnect(session$userData$AquaCache)

--- a/inst/apps/floodAtlas_over/server.R
+++ b/inst/apps/floodAtlas_over/server.R
@@ -17,6 +17,8 @@ app_server <- function(input, output, session) {
                                       username = config$dbUser,
                                       password = config$dbPass,
                                       silent = TRUE)
+
+  session$userData$use_webgl <- !grepl('Android', session$request$HTTP_USER_AGENT, ignore.case = TRUE)
   
 
   session$onUnhandledError(function() {
@@ -151,7 +153,7 @@ app_server <- function(input, output, session) {
   
   # Define the ExtendedTask to generate the plot
   plot_output <- ExtendedTask$new(
-    function(loc, param, yrs, lang, config) {
+    function(loc, param, yrs, lang, webgl, config) {
 
     promises::future_promise({
       
@@ -185,6 +187,7 @@ app_server <- function(input, output, session) {
                   gridx = FALSE,
                   gridy = FALSE,
                   slider = FALSE,
+                  webgl = webgl,
                   hover = FALSE,
                   tzone = "MST",
                   con = con)
@@ -198,7 +201,7 @@ app_server <- function(input, output, session) {
   }) |> bslib::bind_task_button("go") # Changes the look of the task button and disables it while the task is running
   
   observeEvent(params$render, {
-    plot_output$invoke(params$loc_code, params$param_code, params$yrs, params$lang, config)
+    plot_output$invoke(params$loc_code, params$param_code, params$yrs, params$lang, session$userData$use_webgl, config)
   })
   
   output$plot <- plotly::renderPlotly({

--- a/inst/apps/floodAtlas_ts/server.R
+++ b/inst/apps/floodAtlas_ts/server.R
@@ -30,6 +30,7 @@ app_server <- function(input, output, session) {
 
   # Parse URL query parameters on app load from URL and trigger plot creation
   params <- reactiveValues()
+  session$userData$use_webgl <- !grepl('Android', session$request$HTTP_USER_AGENT, ignore.case = TRUE)
   observeEvent(session, {
     query <- parseQueryString(session$clientData$url_search)
     
@@ -105,7 +106,7 @@ app_server <- function(input, output, session) {
   
   # Define the ExtendedTask to generate the plot
   plot_output <- ExtendedTask$new(
-    function(loc, param, lang, config, rate) {
+    function(loc, param, lang, webgl, config, rate) {
 
     promises::future_promise({
       
@@ -136,6 +137,7 @@ app_server <- function(input, output, session) {
                   gridx = FALSE,
                   gridy = FALSE,
                   slider = FALSE,
+                  webgl = webgl,
                   title = TRUE,
                   hover = FALSE,
                   tzone = "MST",
@@ -156,7 +158,7 @@ app_server <- function(input, output, session) {
   observeEvent(input$user_speed, {
     req(params$loc_code, params$param_code, params$lang)
     rate <- if (input$user_speed < 0.0003) "day" else if (input$user_speed < 0.002) "hour" else "max"
-    plot_output$invoke(params$loc_code, params$param_code, params$lang, config, rate)
+    plot_output$invoke(params$loc_code, params$param_code, params$lang, session$userData$use_webgl, config, rate)
   })
   
   output$plot <- plotly::renderPlotly({


### PR DESCRIPTION
## Summary
- add `webgl` argument to plotting functions
- detect the browser user-agent in shiny apps
- switch to standard scatter when running on Android
- propagate new parameter through plotting modules
- remove extra observer for user-agent detection

## Testing
- `devtools::test()` *(fails: `R` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6860999b9220832f867b8c448a188482