### PR TITLE
Improve timeseries plotting performance

### DIFF
--- a/R/calculate_period.R
+++ b/R/calculate_period.R
@@ -17,41 +17,33 @@ calculate_period <- function(data, datetime_col = "datetime", timeseries_id = NU
   data <- data[order(data[[datetime_col]]) ,] #Sort ascending
   diffs <- as.numeric(diff(data[[datetime_col]]), units = "hours")
   smoothed_diffs <- zoo::rollmedian(diffs, k = 3, fill = NA, align = "center")
-  # Initialize variables to track changes
-  consecutive_count <- 0
   changes <- data.frame()
-  last_diff <- 0
-  
-  if (!all(is.na(smoothed_diffs))) {
-    if (length(smoothed_diffs) > 0) {
-      for (j in 1:length(smoothed_diffs)) {
-        if (!is.na(smoothed_diffs[j]) && smoothed_diffs[j] < 25 && smoothed_diffs[j] != last_diff) { # Check if smoothed interval is less than threshold, which is set to more than a whole day (greatest interval possible is 24 hours) as well as not the same as the last recorded diff
-          consecutive_count <- consecutive_count + 1
-          if (consecutive_count == 3) { # At three consecutive new measurements it's starting to look like a pattern
-            last_diff <- smoothed_diffs[j]
-            change <- data.frame(datetime = data[[datetime_col]][j - 3],
-                                 period = last_diff)
-            changes <- rbind(changes, change)
-            consecutive_count <- 0
-          }
-        } else {
-          consecutive_count <- 0
-        }
-      }
+
+  if (!all(is.na(smoothed_diffs)) && length(smoothed_diffs) > 0) {
+    diff_dt <- data.table::data.table(idx = seq_along(smoothed_diffs), diff = smoothed_diffs)
+    diff_dt[, run := data.table::rleid(diff)]
+    runs <- diff_dt[, .(diff = diff[1], start = idx[1], len = .N), by = run]
+    runs <- runs[!is.na(diff) & diff < 25 & len >= 3]
+    if (nrow(runs) > 0) {
+      changes <- data.frame(
+        datetime = data[[datetime_col]][runs$start],
+        period = runs$diff
+      )
     }
   }
 
   
   # Calculate the duration in days, hours, minutes, and seconds and assign to the right location in data
   if (nrow(changes) > 0) {
-    for (j in 1:nrow(changes)) {
-      days <- floor(changes$period[j] / 24)
-      remaining_hours <- changes$period[j] %% 24
+    iso_period <- function(x) {
+      days <- floor(x / 24)
+      remaining_hours <- x %% 24
       minutes <- floor((remaining_hours - floor(remaining_hours)) * 60)
       seconds <- round(((remaining_hours - floor(remaining_hours)) * 60 - minutes) * 60)
-      data[data[[datetime_col]] == changes$datetime[j], "period"] <- paste("P", days, "DT", floor(remaining_hours), "H", minutes, "M", seconds, "S", sep = "")
+      paste0("P", days, "DT", floor(remaining_hours), "H", minutes, "M", seconds, "S")
     }
-    #carry non-na's forward and backwards, if applicable
+    data$period <- NA
+    data[match(changes$datetime, data[[datetime_col]]), "period"] <- iso_period(changes$period)
     data$period <- zoo::na.locf(zoo::na.locf(data$period, na.rm = FALSE), fromLast = TRUE)
     
   } else { #In this case there were too few measurements to conclusively determine a period so pull a few from the DB and redo the calculation
@@ -78,34 +70,31 @@ calculate_period <- function(data, datetime_col = "datetime", timeseries_id = NU
     data <- data[order(data[[datetime_col]]), ]
     diffs <- as.numeric(diff(data[[datetime_col]]), units = "hours")
     smoothed_diffs <- zoo::rollmedian(diffs, k = 3, fill = NA, align = "center")
-    consecutive_count <- 0
     changes <- data.frame()
-    last_diff <- 0
+
     if (length(smoothed_diffs) > 0) {
-      for (j in 1:length(smoothed_diffs)) {
-        if (!is.na(smoothed_diffs[j]) && smoothed_diffs[j] < 25 && smoothed_diffs[j] != last_diff) {
-          consecutive_count <- consecutive_count + 1
-          if (consecutive_count == 3) {
-            last_diff <- smoothed_diffs[j]
-            change <- data.frame(datetime = data[[datetime_col]][j - 3],
-                                 period = last_diff)
-            changes <- rbind(changes, change)
-            consecutive_count <- 0
-          }
-        } else {
-          consecutive_count <- 0
-        }
+      diff_dt <- data.table::data.table(idx = seq_along(smoothed_diffs), diff = smoothed_diffs)
+      diff_dt[, run := data.table::rleid(diff)]
+      runs <- diff_dt[, .(diff = diff[1], start = idx[1], len = .N), by = run]
+      runs <- runs[!is.na(diff) & diff < 25 & len >= 3]
+      if (nrow(runs) > 0) {
+        changes <- data.frame(
+          datetime = data[[datetime_col]][runs$start],
+          period = runs$diff
+        )
       }
     }
+
     if (nrow(changes) > 0) {
-      for (k in 1:nrow(changes)) {
-        days <- floor(changes$period[k] / 24)
-        remaining_hours <- changes$period[k] %% 24
+      iso_period <- function(x) {
+        days <- floor(x / 24)
+        remaining_hours <- x %% 24
         minutes <- floor((remaining_hours - floor(remaining_hours)) * 60)
         seconds <- round(((remaining_hours - floor(remaining_hours)) * 60 - minutes) * 60)
-        data[data[[datetime_col]] == changes[[datetime_col]][k], "period"] <- paste("P", days, "DT", floor(remaining_hours), "H", minutes, "M", seconds, "S", sep = "")
+        paste0("P", days, "DT", floor(remaining_hours), "H", minutes, "M", seconds, "S")
       }
-      #carry non-na's forward and backwards, if applicable
+      data$period <- NA
+      data[match(changes$datetime, data[[datetime_col]]), "period"] <- iso_period(changes$period)
       data$period <- zoo::na.locf(zoo::na.locf(data$period, na.rm = FALSE), fromLast = TRUE)
     } else {
       data$period <- NULL

--- a/R/plotTimeseries.R
+++ b/R/plotTimeseries.R
@@ -649,109 +649,79 @@ plotTimeseries <- function(location,
                       text = ~paste0(parameter_name, ": ", round(value, 4), " (", datetime, ")"))
   
   # Add the grades, approvals, qualifiers as ribbons below the plotting area
-  # make a function to add the bands, used for all three
   if (any(grades, approvals, qualifiers)) {
     slider <- FALSE
-    buildBandPlot <- function(df, category_col) {
-      #For each row, add a horizontal segment or filled area
-      p <- plotly::plot_ly()
-      
-      for (i in seq_len(nrow(df))) {
-        start_x <- df$start_dt[i]
-        end_x <- df$end_dt[i]
-        p <- p %>%
-          plotly::add_polygons(
-            x = c(start_x, start_x, end_x, end_x),
-            y = c(0, 1, 1, 0),
-            fill = "toself",
-            fillcolor = "lightblue",
-            line = list(width = 1, color = "black"),
-            hoverinfo = "text",
-            hoveron = "fills",
-            text = paste(category_col, ":", df[[category_col]][i]),
-            showlegend = FALSE
-          )
-      }
-      p <- p %>% plotly::layout(
-        yaxis = list(showticklabels = FALSE, showgrid = FALSE, range = c(0, 2), zeroline = FALSE),
-        xaxis = list(showgrid = FALSE)
-      )
-      return(p)
-    }
-    
     bands_subplot <- plotly::plot_ly()
-    
-    # extract the start of the trace_data
+
     mindt <- trace_data[, min(datetime)]
     maxdt <- trace_data[, max(datetime)]
-    
+
+    poly_list <- list()
+
     if (approvals) {
       approvals_y_set <- if (grades & qualifiers) c(2.2, 3.2, 3.2, 2.2) else if (grades) c(1.1, 2.1, 2.1, 1.1) else c(0, 1, 1, 0)
-      # Adjust start_dt occurrences which are before the start of the trace_data
-      approvals_dt[start_dt < mindt, "start_dt" := mindt]
-      # Adjust end_dt occurrences which are after the end of the trace_data
-      approvals_dt[end_dt > maxdt, "end_dt" := maxdt]
-      for (i in seq_len(nrow(approvals_dt))) {
-        start_x <- approvals_dt$start_dt[i]
-        end_x <- approvals_dt$end_dt[i]
-        color <- approvals_dt$color_code[i]
-        bands_subplot <- bands_subplot %>%
-          plotly::add_polygons(
-            x = c(start_x, start_x, end_x, end_x),
-            y = approvals_y_set,
-            fill = "toself",
-            fillcolor = color,
-            line = list(width = 1, color = "black"),
-            hoverinfo = "text",
-            hoveron = "fills",
-            text = if (lang == "en") paste("Approval:", approvals_dt$approval_type_description[i]) else paste0("Approbation:", approvals_dt$approval_type_description_fr[i]),
-            showlegend = FALSE
-          )
+      approvals_dt[start_dt < mindt, start_dt := mindt]
+      approvals_dt[end_dt > maxdt, end_dt := maxdt]
+      if (nrow(approvals_dt) > 0) {
+        approvals_dt[, id := paste0("approval_", .I)]
+        poly_list[[length(poly_list) + 1]] <- approvals_dt[, .(
+          datetime = c(start_dt, start_dt, end_dt, end_dt),
+          y = approvals_y_set,
+          color = color_code,
+          text = if (lang == "en") paste0("Approval: ", approval_type_description) else paste0("Approbation:", approval_type_description_fr),
+          id = id
+        ), by = id]
       }
     }
+
     if (grades) {
-      grades_y_set <- if (qualifiers)  c(1.1, 2.1, 2.1, 1.1) else c(0, 1, 1, 0)
-      grades_dt[start_dt < mindt, "start_dt" := mindt]
-      grades_dt[end_dt > maxdt, "end_dt" := maxdt]
-      for (i in seq_len(nrow(grades_dt))) {
-        start_x <- grades_dt$start_dt[i]
-        end_x <- grades_dt$end_dt[i]
-        color <- grades_dt$color_code[i]
-        bands_subplot <- bands_subplot %>%
-          plotly::add_polygons(
-            x = c(start_x, start_x, end_x, end_x),
-            y = grades_y_set,
-            fill = "toself",
-            fillcolor = color,
-            line = list(width = 1, color = "black"),
-            hoverinfo = "text",
-            hoveron = "fills",
-            text = if (lang == "en") paste("Grade:", grades_dt$grade_type_description[i]) else paste0("Cote:", grades_dt$grade_type_description_fr[i]),
-            showlegend = FALSE
-          )
+      grades_y_set <- if (qualifiers) c(1.1, 2.1, 2.1, 1.1) else c(0, 1, 1, 0)
+      grades_dt[start_dt < mindt, start_dt := mindt]
+      grades_dt[end_dt > maxdt, end_dt := maxdt]
+      if (nrow(grades_dt) > 0) {
+        grades_dt[, id := paste0("grade_", .I)]
+        poly_list[[length(poly_list) + 1]] <- grades_dt[, .(
+          datetime = c(start_dt, start_dt, end_dt, end_dt),
+          y = grades_y_set,
+          color = color_code,
+          text = if (lang == "en") paste0("Grade: ", grade_type_description) else paste0("Cote:", grade_type_description_fr),
+          id = id
+        ), by = id]
       }
     }
+
     if (qualifiers) {
       qualifiers_y_set <- c(0, 1, 1, 0)
-      qualifiers_dt[start_dt < mindt, "start_dt" := mindt]
-      qualifiers_dt[end_dt > maxdt, "end_dt" := maxdt]
-      for (i in seq_len(nrow(qualifiers_dt))) {
-        start_x <- qualifiers_dt$start_dt[i]
-        end_x <- qualifiers_dt$end_dt[i]
-        color <- qualifiers_dt$color_code[i]
-        bands_subplot <- bands_subplot %>%
-          plotly::add_polygons(
-            x = c(start_x, start_x, end_x, end_x),
-            y = qualifiers_y_set,
-            fill = "toself",
-            fillcolor = color,
-            line = list(width = 1, color = "black"),
-            hoverinfo = "text",
-            hoveron = "fills",
-            text = if (lang == "en") paste("Qualifier:", qualifiers_dt$qualifier_type_description[i]) else paste0("Qualificatif:", qualifiers_dt$qualifier_type_description_fr[i]),
-            showlegend = FALSE
-          )
+      qualifiers_dt[start_dt < mindt, start_dt := mindt]
+      qualifiers_dt[end_dt > maxdt, end_dt := maxdt]
+      if (nrow(qualifiers_dt) > 0) {
+        qualifiers_dt[, id := paste0("qualifier_", .I)]
+        poly_list[[length(poly_list) + 1]] <- qualifiers_dt[, .(
+          datetime = c(start_dt, start_dt, end_dt, end_dt),
+          y = qualifiers_y_set,
+          color = color_code,
+          text = if (lang == "en") paste0("Qualifier: ", qualifier_type_description) else paste0("Qualificatif:", qualifier_type_description_fr),
+          id = id
+        ), by = id]
       }
+    }
+
+    if (length(poly_list) > 0) {
+      polygons_df <- data.table::rbindlist(poly_list, use.names = TRUE)
+      bands_subplot <- bands_subplot %>%
+        plotly::add_polygons(
+          data = polygons_df,
+          x = ~datetime,
+          y = ~y,
+          split = ~id,
+          fill = "toself",
+          fillcolor = ~color,
+          line = list(width = 1, color = "black"),
+          hoverinfo = "text",
+          hoveron = "fills",
+          text = ~text,
+          showlegend = FALSE
+        )
     }
     
     # Hide the y axis labels and replace with annotations


### PR DESCRIPTION
## Summary
- vectorize periodicity calculation in `calculate_period`
- reduce plotly polygon traces by batching grade/approval/qualifier ribbons

## Testing
- `R -q -e "library(testthat); test_dir('tests/testthat')"` *(fails: R not found)*

------
https://chatgpt.com/codex/tasks/task_b_6861ff30cba0832fb1c990bd2be956aa