### PR TITLE
Add keep-alive heartbeat to Shiny apps

### DIFF
--- a/inst/apps/YGwater/server.R
+++ b/inst/apps/YGwater/server.R
@@ -6,9 +6,14 @@
 #' @noRd
 
 app_server <- function(input, output, session) {
-  
+
   # Initial setup #############################################################
-  
+
+  output$keep_alive <- renderText({
+    invalidateLater(5000, session)
+    Sys.time()
+  })
+
   # Hide all 'admin' side tabs if they were generated
   
   # Show relevant tabs for viz mode

--- a/inst/apps/YGwater/ui.R
+++ b/inst/apps/YGwater/ui.R
@@ -12,6 +12,7 @@ app_ui <- function(request) {
   
   tagList(
     shinyjs::useShinyjs(),
+    div(id = "keep_alive", style = "display:none;", textOutput("keep_alive")),
     # Define a JavaScript function to change the background color of an element. If used within a module, MUST refer to variables with ns().
     # Uses two parameters: 'id' for the element ID and 'col' for the color. Color can be R-recognized color name or hex code.
     shinyjs::extendShinyjs(

--- a/inst/apps/floodAtlas_over/server.R
+++ b/inst/apps/floodAtlas_over/server.R
@@ -7,8 +7,13 @@
 
 
 app_server <- function(input, output, session) {
-  
+
   # Initial setup #############################################################
+
+  output$keep_alive <- renderText({
+    invalidateLater(5000, session)
+    Sys.time()
+  })
   
   # Connection to DB
   session$userData$con <- AquaConnect(name = config$dbName,

--- a/inst/apps/floodAtlas_over/ui.R
+++ b/inst/apps/floodAtlas_over/ui.R
@@ -9,6 +9,7 @@ app_ui <- function(request) {
   
   fluidPage(
     shinyjs::useShinyjs(),
+    div(id = "keep_alive", style = "display:none;", textOutput("keep_alive")),
 
     tags$head(
       tags$link(rel = "stylesheet", type = "text/css", href = "css/fonts.css"), # YG fonts (the CSS refers to files in the www/fonts folder so there is no external dependency)

--- a/inst/apps/floodAtlas_ts/server.R
+++ b/inst/apps/floodAtlas_ts/server.R
@@ -6,8 +6,13 @@
 #' @noRd
 
 app_server <- function(input, output, session) {
-  
+
   # Initial setup #############################################################
+
+  output$keep_alive <- renderText({
+    invalidateLater(5000, session)
+    Sys.time()
+  })
   
   # Remove irrelevant bookmarks
   setBookmarkExclude(c("plot", "error", "info", ".clientValue-default-plotlyCrosstalkOpts", "plotly_afterplot-A", "plotly_hover-A", "plotly_relayout-A", "plotly_doubleclick-A"))

--- a/inst/apps/floodAtlas_ts/ui.R
+++ b/inst/apps/floodAtlas_ts/ui.R
@@ -9,6 +9,7 @@ app_ui <- function(request) {
   
   fluidPage(
     shinyjs::useShinyjs(),
+    div(id = "keep_alive", style = "display:none;", textOutput("keep_alive")),
     tags$script(src = "js/check_speed.js"),
     tags$head(
       tags$link(rel = "stylesheet", type = "text/css", href = "css/fonts.css"), # YG fonts (the CSS refers to files in the www/fonts folder so there is no external dependency)


### PR DESCRIPTION
## Summary
- add an invisible heartbeat element in each app UI
- refresh the heartbeat every five seconds on the server

## Testing
- `R -q -e "library(testthat); test_dir('tests/testthat')"` *(fails: could not find function `check_miniconda_installed`)*

------
https://chatgpt.com/codex/tasks/task_b_6860a5401950832f9b7a46421d117a52