### PR TITLE
Improve snapshot determinism

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -91,6 +91,7 @@ Suggests:
     tibble,
     vdiffr,
     weathercan,
+    ragg,
     withr,
     zipR
 Remotes:

--- a/R/plotDiscrete.R
+++ b/R/plotDiscrete.R
@@ -851,7 +851,8 @@ AND s.datetime > '", start, "' AND s.datetime < '", end, "';
                                     tickfont = list(size = axis_scale * 14)),
                        legend = list(font = list(size = legend_scale * 14),
                                      orientation = legend_position
-                                     )
+                                     ),
+                       font = list(family = "DejaVu Sans")
                        )
       
       if (nrow(conditions) > 0) {
@@ -965,14 +966,15 @@ AND s.datetime > '", start, "' AND s.datetime < '", end, "';
     
 
     # Apply the layout settings to the final plot
-    final_plot <- plotly::subplot(plots, 
+    final_plot <- plotly::subplot(plots,
                                   nrows = nrows,
                                   shareX = FALSE,
                                   shareY = FALSE,
-                                  titleX = FALSE, 
+                                  titleX = FALSE,
                                   titleY = TRUE,
-                                  margin = margins) %>% 
-       plotly::layout(showlegend = TRUE)
+                                  margin = margins) %>%
+       plotly::layout(showlegend = TRUE,
+                      font = list(family = "DejaVu Sans"))
     
     # Link axes if desired
     if (shareX || shareY) {

--- a/R/plotMultiTimeseries.R
+++ b/R/plotMultiTimeseries.R
@@ -902,8 +902,8 @@ plotMultiTimeseries <- function(type = 'traces',
     
     # Add other layout parameters
     layout_params <- list(
-      title = list(text = title, 
-                   x = 0.05, 
+      title = list(text = title,
+                   x = 0.05,
                    xref = "container",
                    font = list(size = 18 * axis_scale)),
       margin = list(
@@ -923,7 +923,8 @@ plotMultiTimeseries <- function(type = 'traces',
       ),
       hovermode = "closest",
       legend = list(font = list(size = legend_scale * 12),
-                    orientation = legend_position)
+                    orientation = legend_position),
+      font = list(family = "DejaVu Sans")
     )
     
     # Combine axis layouts with other layout settings
@@ -1029,7 +1030,8 @@ plotMultiTimeseries <- function(type = 'traces',
                         l = 50 * axis_scale), 
           hovermode = "x unified",
           legend = list(font = list(size = legend_scale * 12),
-                        orientation = legend_position)
+                        orientation = legend_position),
+          font = list(family = "DejaVu Sans")
         ) %>%
         plotly::config(locale = lang)
       
@@ -1055,14 +1057,15 @@ plotMultiTimeseries <- function(type = 'traces',
         font = list(size = 16 * axis_scale)
       )
     }
-    plot <- plotly::subplot(subplots, 
-                            nrows = nrows, 
-                            shareX = FALSE, 
-                            shareY = FALSE, 
-                            titleX = FALSE, 
-                            titleY = TRUE, 
+    plot <- plotly::subplot(subplots,
+                            nrows = nrows,
+                            shareX = FALSE,
+                            shareY = FALSE,
+                            titleX = FALSE,
+                            titleY = TRUE,
                             margin = c(0, (0.07 * axis_scale), 0, (0.07 * axis_scale))) %>%
-      plotly::layout(annotations = subtitles)
+      plotly::layout(annotations = subtitles,
+                     font = list(family = "DejaVu Sans"))
     
     # Link axes if desired
     if (shareX || shareY) {

--- a/R/plotOverlap.R
+++ b/R/plotOverlap.R
@@ -763,11 +763,11 @@ plotOverlap <- function(location,
   
   plot <- plot %>%
     plotly::layout(
-      title = if (title) list(text = stn_name, 
-                              x = 0.05, 
+      title = if (title) list(text = stn_name,
+                              x = 0.05,
                               xref = "container",
                               font = list(size = axis_scale * 18))
-      else NULL, 
+      else NULL,
       xaxis = list(title = list(standoff = 0), 
                    showgrid = gridx, 
                    showline = TRUE, 
@@ -796,7 +796,8 @@ plotOverlap <- function(location,
                     t = 40 * axis_scale,
                     l = 50 * axis_scale), 
       hovermode = if (hover) "x unified" else ("none"),
-      legend = list(font = list(size = legend_scale * 12))
+      legend = list(font = list(size = legend_scale * 12)),
+      font = list(family = "DejaVu Sans")
     ) %>%
     plotly::config(locale = lang)
   

--- a/R/plotTimeseries.R
+++ b/R/plotTimeseries.R
@@ -779,7 +779,8 @@ plotTimeseries <- function(location,
       plotly::layout(
         yaxis = list(showticklabels = FALSE, showgrid = FALSE, zeroline = FALSE),
         xaxis = list(showgrid = FALSE),
-        annotations = annotation_list
+        annotations = annotation_list,
+        font = list(family = "DejaVu Sans")
       )
     
     
@@ -795,11 +796,11 @@ plotTimeseries <- function(location,
   
   plot <- plot %>%
     plotly::layout(
-      title = if (title) list(text = stn_name, 
-                              x = 0.05, 
+      title = if (title) list(text = stn_name,
+                              x = 0.05,
                               xref = "container",
                               font = list(size = axis_scale * 18))
-      else NULL, 
+      else NULL,
       xaxis = list(title = list(standoff = 0), 
                    showgrid = gridx, 
                    showline = TRUE, 
@@ -829,7 +830,8 @@ plotTimeseries <- function(location,
                     l = 50 * axis_scale), 
       hovermode = if (hover) "x unified" else ("none"),
       legend = list(font = list(size = legend_scale * 12),
-                    orientation = legend_position)
+                    orientation = legend_position),
+      font = list(family = "DejaVu Sans")
     ) %>%
     plotly::config(locale = lang)
   

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -42,3 +42,11 @@ if (Sys.getenv("CI") == "true") {
 }
 
 set.seed(123) # Set seed for reproducibility in tests
+
+# Ensure ragg is available for deterministic PNG output
+if (!requireNamespace("ragg", quietly = TRUE)) {
+  install.packages("ragg")
+}
+
+# Use a stable base font across platforms
+ggplot2::theme_set(ggplot2::theme_gray(base_family = "DejaVu Sans"))

--- a/tests/testthat/test-ggplotOverlap.R
+++ b/tests/testthat/test-ggplotOverlap.R
@@ -14,7 +14,7 @@ test_that("continuous level plot is as expected for full year with numeric start
   
   plot <- ggplotOverlap("09EA004", "water level", startDay = 1, endDay = 365, years = "2022", historic_range = "last", gridx = FALSE)
   # Save the plot as png
-  suppressMessages(ggplot2::ggsave(filename = path, plot = plot, width = 10, height = 6, dpi = 300))
+  suppressMessages(ggplot2::ggsave(filename = path, plot = plot, width = 10, height = 6, dpi = 300, device = ragg::agg_png))
   
   expect_snapshot_file(path)
 })
@@ -27,7 +27,7 @@ test_that("french labels work with full year", {
   on.exit(unlink(path), add = TRUE)
   
   plot <- ggplotOverlap("09EA004", "water level", startDay = 1, endDay = 365, years = "2022", historic_range = "last", lang = "fr", gridx = FALSE)
-  ggplot2::ggsave(filename = path, plot = plot, width = 10, height = 6, dpi = 300)
+  ggplot2::ggsave(filename = path, plot = plot, width = 10, height = 6, dpi = 300, device = ragg::agg_png)
   
   expect_snapshot_file(path)
 })
@@ -40,7 +40,7 @@ test_that("continuous level plot is as expected for full year with numeric start
   on.exit(unlink(path), add = TRUE)
   
   plot <- suppressWarnings(ggplotOverlap("09EA004", "water level", startDay = 1, endDay = 365, years = "2022", historic_range = "last", gridx = TRUE, gridy = TRUE))
-  ggplot2::ggsave(filename = path, plot = plot, width = 10, height = 6, dpi = 300)
+  ggplot2::ggsave(filename = path, plot = plot, width = 10, height = 6, dpi = 300, device = ragg::agg_png)
   
   expect_snapshot_file(path)
 })
@@ -53,7 +53,7 @@ test_that("continuous level plot is as expected for full year with character sta
   on.exit(unlink(path), add = TRUE)
   
   plot <- ggplotOverlap("09EA004", "water level", startDay = "2023-01-01", endDay = "2023-12-31", years = "2021", save_path = NULL, historic_range = "last", gridx = FALSE)
-  ggplot2::ggsave(filename = path, plot = plot, width = 10, height = 6, dpi = 300)
+  ggplot2::ggsave(filename = path, plot = plot, width = 10, height = 6, dpi = 300, device = ragg::agg_png)
   
   expect_snapshot_file(path)
 })
@@ -66,7 +66,7 @@ test_that("continuous flow plot is as expected for full year with numeric startD
   on.exit(unlink(path), add = TRUE)
   
   plot <- ggplotOverlap("09EA004", "flow", startDay = 1, endDay = 365, years = "2020", save_path = NULL, historic_range = "last", gridx = FALSE)
-  ggplot2::ggsave(filename = path, plot = plot, width = 10, height = 6, dpi = 300)
+  ggplot2::ggsave(filename = path, plot = plot, width = 10, height = 6, dpi = 300, device = ragg::agg_png)
   
   expect_snapshot_file(path)
 })
@@ -83,7 +83,7 @@ test_that("SWE plot works when overlaping new year, dates as character", {
   on.exit(unlink(path), add = TRUE)
   
   plot <- ggplotOverlap("09AA-M1", "snow water equivalent", startDay = "2023-09-01", endDay = "2023-05-31", years = "2022", save_path = NULL, return_months = c(4,5), historic_range = "last", datum = FALSE, gridx = FALSE)
-  ggplot2::ggsave(filename = path, plot = plot, width = 10, height = 6, dpi = 300)
+  ggplot2::ggsave(filename = path, plot = plot, width = 10, height = 6, dpi = 300, device = ragg::agg_png)
   
   expect_snapshot_file(path)
 })
@@ -96,7 +96,7 @@ test_that("depth plot works when overlaping new year, dates as numeric", {
   on.exit(unlink(path), add = TRUE)
   
   plot <- ggplotOverlap("09AA-M1", "snow depth", startDay = 250, endDay = 150, years = "2022", save_path = NULL, return_months = c(4,5), historic_range = "last", datum = FALSE, gridx = FALSE)
-  ggplot2::ggsave(filename = path, plot = plot, width = 10, height = 6, dpi = 300)
+  ggplot2::ggsave(filename = path, plot = plot, width = 10, height = 6, dpi = 300, device = ragg::agg_png)
   
   expect_snapshot_file(path)
 })
@@ -109,7 +109,7 @@ test_that("french labels work with overlaping years", {
   on.exit(unlink(path), add = TRUE)
   
   plot <- ggplotOverlap("09AA-M1", "snow depth", startDay = 250, endDay = 150, years = "2022", save_path = NULL, return_months = c(4,5), historic_range = "last", lang = "fr", gridx = FALSE)
-  ggplot2::ggsave(filename = path, plot = plot, width = 10, height = 6, dpi = 300)
+  ggplot2::ggsave(filename = path, plot = plot, width = 10, height = 6, dpi = 300, device = ragg::agg_png)
   
   expect_snapshot_file(path)
 })
@@ -122,7 +122,7 @@ test_that("continuous level plot is as expected for multiple years when output t
   on.exit(unlink(path), add = TRUE)
   
   plot <- suppressWarnings(ggplotOverlap("09EA004", "water level", startDay = 1, endDay = 365, years = c(2021,2022), historic_range = "last", gridx = FALSE))
-  ggplot2::ggsave(filename = path, plot = plot, width = 10, height = 6, dpi = 300)
+  ggplot2::ggsave(filename = path, plot = plot, width = 10, height = 6, dpi = 300, device = ragg::agg_png)
   
   expect_snapshot_file(path)
 })
@@ -140,7 +140,7 @@ test_that("historic range can be < requested year", {
   on.exit(unlink(path), add = TRUE)
   
   plot <- suppressWarnings(ggplotOverlap("09EA004", "water level", startDay = 1, endDay = 365, years = c(2022), historic_range = "all", gridx = FALSE))
-  ggplot2::ggsave(filename = path, plot = plot, width = 10, height = 6, dpi = 300)
+  ggplot2::ggsave(filename = path, plot = plot, width = 10, height = 6, dpi = 300, device = ragg::agg_png)
   
   expect_snapshot_file(path)
 })


### PR DESCRIPTION
## Summary
- add `ragg` to DESCRIPTION and install it for tests
- set base theme family in test setup
- save ggplot snapshots using `ragg::agg_png`
- specify font family for plotly layout calls

## Testing
- `apt-get update` *(fails: Invalid response from proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68885a7a94e0832fbd2765d4fbd02ccf