### PR TITLE
Use glue_sql for user-provided query values

### DIFF
--- a/R/plotMultiTimeseries.R
+++ b/R/plotMultiTimeseries.R
@@ -384,20 +384,20 @@ plotMultiTimeseries <- function(type = 'traces',
     
     if (inherits(location, "character")) {
       # Try to find the location_id from a character string
-      location_id <- DBI::dbGetQuery(con, paste0("SELECT location_id FROM locations WHERE location = '", location, "';"))[1,1]
+      location_id <- DBI::dbGetQuery(con, glue::glue_sql("SELECT location_id FROM locations WHERE location = {location};", .con = con))[1,1]
       if (is.na(location_id)) {
-        location_id <- DBI::dbGetQuery(con, paste0("SELECT location_id FROM locations WHERE name = '", location, "';"))[1,1]
+        location_id <- DBI::dbGetQuery(con, glue::glue_sql("SELECT location_id FROM locations WHERE name = {location};", .con = con))[1,1]
       }
       if (is.na(location_id)) {
-        location_id <- DBI::dbGetQuery(con, paste0("SELECT location_id FROM locations WHERE name_fr = '", location, "';"))[1,1]
+        location_id <- DBI::dbGetQuery(con, glue::glue_sql("SELECT location_id FROM locations WHERE name_fr = {location};", .con = con))[1,1]
       }
       # If nothing so far, maybe it's a numeric that's masquerading as a character
       if (is.na(location_id)) {
-        location_id <- DBI::dbGetQuery(con, paste0("SELECT location_id FROM locations WHERE location_id = ", location, ";"))[1,1]
+        location_id <- DBI::dbGetQuery(con, glue::glue_sql("SELECT location_id FROM locations WHERE location_id = {location};", .con = con))[1,1]
       }
     } else {
       # Try to find the location_id from a numeric value
-      location_id <- DBI::dbGetQuery(con, paste0("SELECT location_id FROM locations WHERE location_id = ", location, ";"))[1,1]
+      location_id <- DBI::dbGetQuery(con, glue::glue_sql("SELECT location_id FROM locations WHERE location_id = {location};", .con = con))[1,1]
     }
     
     if (is.na(location_id)) {
@@ -410,10 +410,9 @@ plotMultiTimeseries <- function(type = 'traces',
     if (!is.null(sub_location)) {
       if (inherits(sub_location, "character")) {
         sub_location <- tolower(sub_location)
-        escaped_sub_location <- gsub("'", "''", sub_location)
-        sub_location_id <- DBI::dbGetQuery(con, paste0("SELECT sub_location_id FROM sub_locations WHERE sub_location_name = '", escaped_sub_location, "' OR sub_location_name_fr = '", escaped_sub_location, "';"))[1,1]
+          sub_location_id <- DBI::dbGetQuery(con, glue::glue_sql("SELECT sub_location_id FROM sub_locations WHERE sub_location_name = {sub_location} OR sub_location_name_fr = {sub_location};", .con = con))[1,1]
       } else { # Check if the sub_location_id exists
-        sub_location_id <- DBI::dbGetQuery(con, paste0("SELECT sub_location_id FROM sub_locations WHERE sub_location_id = ", sub_location, ";"))[1,1]
+        sub_location_id <- DBI::dbGetQuery(con, glue::glue_sql("SELECT sub_location_id FROM sub_locations WHERE sub_location_id = {sub_location};", .con = con))[1,1]
       }
       if (is.na(sub_location_id)) {
         warning("The sub-location you entered for location ", location, ", sub-location ", sub_location, " does not exist in the database. Moving on to the next entry.")
@@ -424,8 +423,7 @@ plotMultiTimeseries <- function(type = 'traces',
     }
     if (inherits(parameter, "character")) {
       parameter <- tolower(parameter)
-      escaped_parameter <- gsub("'", "''", parameter)
-      parameter_tbl <- DBI::dbGetQuery(con, paste0("SELECT parameter_id, param_name, param_name_fr, plot_default_y_orientation, unit_default FROM parameters WHERE param_name = '", escaped_parameter, "' OR param_name_fr = '", escaped_parameter, "';"))
+      parameter_tbl <- DBI::dbGetQuery(con, glue::glue_sql("SELECT parameter_id, param_name, param_name_fr, plot_default_y_orientation, unit_default FROM parameters WHERE param_name = {parameter} OR param_name_fr = {parameter};", .con = con))
       parameter_code <- parameter_tbl$parameter_id[1]
       if (is.na(parameter_code)) {
         warning("The parameter you entered for location ", location, ", parameter ", parameter, " does not exist in the database. Moving on to the next entry.")
@@ -433,7 +431,7 @@ plotMultiTimeseries <- function(type = 'traces',
         next
       }
     } else if (inherits(parameter, "numeric")) {
-      parameter_tbl <- DBI::dbGetQuery(con, paste0("SELECT parameter_id, param_name, param_name_fr, plot_default_y_orientation, unit_default FROM parameters WHERE parameter_id = ", parameter, ";"))
+      parameter_tbl <- DBI::dbGetQuery(con, glue::glue_sql("SELECT parameter_id, param_name, param_name_fr, plot_default_y_orientation, unit_default FROM parameters WHERE parameter_id = {parameter};", .con = con))
       if (nrow(parameter_tbl) == 0) {
         warning("The parameter code you entered for location ", location, ", parameter ", parameter, " does not exist in the database. Moving on to the next entry.")
         remove <- c(remove, i)

--- a/R/plotTimeseries.R
+++ b/R/plotTimeseries.R
@@ -211,18 +211,18 @@ plotTimeseries <- function(location,
     # Try to find the location_id from a character string
     location_id <- DBI::dbGetQuery(con, glue::glue_sql("SELECT location_id FROM locations WHERE location = {location};", .con = con))[1,1]
     if (is.na(location_id)) {
-      location_id <- DBI::dbGetQuery(con, paste0("SELECT location_id FROM locations WHERE name = {location};", .con = con))[1,1]
+      location_id <- DBI::dbGetQuery(con, glue::glue_sql("SELECT location_id FROM locations WHERE name = {location};", .con = con))[1,1]
     }
     if (is.na(location_id)) {
-      location_id <- DBI::dbGetQuery(con, paste0("SELECT location_id FROM locations WHERE name_fr = {location};", .con = con))[1,1]
+      location_id <- DBI::dbGetQuery(con, glue::glue_sql("SELECT location_id FROM locations WHERE name_fr = {location};", .con = con))[1,1]
     }
     # If nothing so far, maybe it's a numeric that's masquerading as a character
     if (is.na(location_id)) {
-      location_id <- DBI::dbGetQuery(con, paste0("SELECT location_id FROM locations WHERE location_id = {location};", .con = con))[1,1]
+      location_id <- DBI::dbGetQuery(con, glue::glue_sql("SELECT location_id FROM locations WHERE location_id = {location};", .con = con))[1,1]
     }
   } else {
     # Try to find the location_id from a numeric value
-    location_id <- DBI::dbGetQuery(con, paste0("SELECT location_id FROM locations WHERE location_id = {location};", .con = con))[1,1]
+    location_id <- DBI::dbGetQuery(con, glue::glue_sql("SELECT location_id FROM locations WHERE location_id = {location};", .con = con))[1,1]
   }
   if (is.na(location_id)) {
     stop("The location you entered does not exist in the database.")


### PR DESCRIPTION
## Summary
- guard location lookup in `plotTimeseries` with `glue_sql`
- use `glue_sql` for aggregation, location, parameter and sub-location lookups in overlap & multi-timeseries plotting helpers
- parameterize EQWin queries in `plotDiscrete` for standards, groups, locations and sample selection

## Testing
- `Rscript -e 'devtools::test()'` *(fails: there is no package called ‘devtools’)*

------
https://chatgpt.com/codex/tasks/task_b_688bac2d46e8832f80005a2bc629a50c