### PR TITLE
Remove XML dependency from Rmd reports

### DIFF
--- a/inst/rmd/Condition_report.Rmd
+++ b/inst/rmd/Condition_report.Rmd
@@ -1039,7 +1039,14 @@ if (meteogram==TRUE){
 #This section will contain auto-generated images, selected based on the stations(s) selected.
 
 tryCatch({
-  images <- XML::readHTMLTable(httr::content(httr::GET("https://collaboration.cmc.ec.gc.ca/cmc/hydrometric_additionalData/FieldData/YT/", config=httr::authenticate(Sys.getenv("ECCCUSER"), Sys.getenv("ECCCPASS"))), "text"))[[1]]
+  html <- httr::content(
+    httr::GET(
+      "https://collaboration.cmc.ec.gc.ca/cmc/hydrometric_additionalData/FieldData/YT/",
+      config = httr::authenticate(Sys.getenv("ECCCUSER"), Sys.getenv("ECCCPASS"))
+    ),
+    "text"
+  )
+  images <- rvest::html_table(xml2::read_html(html))[[1]]
   images <- images[c(-1,-2),-1] #first two rows are not files and first column is nothing
   images <- images[grep(paste(stations, collapse="|"), images$Name), ] #subset only the images that match stations requested
   images <- images %>% dplyr::filter((as.POSIXct(images[,2], tz="UTC")-7*60*60) >= Sys.Date()-7) #Subsets only images < 7 days old.

--- a/inst/rmd/Freshet_report.Rmd
+++ b/inst/rmd/Freshet_report.Rmd
@@ -1097,9 +1097,16 @@ if (meteogram==TRUE){
 if (WSC_images) {
   tryCatch({
     cat("  \n  \newpage  \n")
-    images <- XML::readHTMLTable(httr::content(httr::GET("https://collaboration.cmc.ec.gc.ca/cmc/hydrometric_additionalData/FieldData/YT/", config=httr::authenticate(Sys.getenv("ECCCUSER"), Sys.getenv("ECCCPASS"))), "text"))[[1]]
+    html <- httr::content(
+      httr::GET(
+        "https://collaboration.cmc.ec.gc.ca/cmc/hydrometric_additionalData/FieldData/YT/",
+        config = httr::authenticate(Sys.getenv("ECCCUSER"), Sys.getenv("ECCCPASS"))
+      ),
+      "text"
+    )
+    images <- rvest::html_table(xml2::read_html(html))[[1]]
     images <- images[c(-1,-2),-1] #first two rows are not files and first column is nothing
-    images <- images[grep(paste(stations, collapse="|"), images$Name), ] #subset only the images that match stations requested 
+    images <- images[grep(paste(stations, collapse="|"), images$Name), ] #subset only the images that match stations requested
     images <- images %>% dplyr::filter((as.POSIXct(images[,2], tz="UTC")-7*60*60) >= Sys.Date()-7) #Subsets only images < 7 days old.
     
     


### PR DESCRIPTION
## Summary
- Replace `XML::readHTMLTable` with `rvest::html_table` and `xml2::read_html` in `Condition_report.Rmd`
- Apply the same change to `Freshet_report.Rmd`

## Testing
- `R CMD check --no-manual --no-build-vignettes .` *(fails: Required fields missing or empty: 'Author' 'Maintainer')*
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: there is no package called ‘testthat’)*

------
https://chatgpt.com/codex/tasks/task_b_6896c42311dc832f9ca55a4b70266234