### PR TITLE
Refactor plot rendering in simplerIndex module

### DIFF
--- a/inst/apps/YGwater/modules/admin/boreholes_wells/simplerIndex.R
+++ b/inst/apps/YGwater/modules/admin/boreholes_wells/simplerIndex.R
@@ -1138,124 +1138,100 @@ simplerIndex <- function(id) {
             })
           }
         }
-        ocr_processing(FALSE)
-      }
-    })
-    
-    # Force plot re-render when pdf_index changes (to show OCR overlays)
-    observeEvent(rv$pdf_index, {
+    ocr_processing(FALSE)
+  }
+})
+
+    # Render current PDF page with OCR overlays and redaction rectangles
+    output$pdf_plot <- renderPlot({
       req(rv$files_df)
       req(rv$pdf_index)
-      
-      # Reset OCR mode selectize to "none" when switching pages
-      #updateSelectizeInput(session, "ocr_display_mode", selected = "none")
-      
-      plot_id <- paste0("pdf_plot_", rv$pdf_index)
-      output[[plot_id]] <- renderPlot({
-        print("Rendering plot within observeEvent")
-        # Load and prepare the image
-        img_path <- rv$files_df$Path[rv$pdf_index]
-        img <- magick::image_read(img_path)
-        img <- img %>% magick::image_enhance()
-        info <- magick::image_info(img)
-        img_width <- info$width
-        img_height <- info$height
-        img_raster <- as.raster(img)
-        
-        # Set up the plot area
-        par(mar = c(0, 0, 0, 0), xaxs = "i", yaxs = "i")
-        plot(0, 0, type = "n", xlim = c(0, img_width), ylim = c(0, img_height),
-             xlab = "", ylab = "", axes = FALSE, asp = 1)
-        
-        # Draw the image
-        rasterImage(img_raster, 0, 0, img_width, img_height)
-        
-        # Show processing indicator if OCR is running
-        if (ocr_processing()) {
-          rect(10, 10, 300, 50, col = "black", border = NA)
-          text(150, 30, "OCR Processing...", col = "white", cex = 1.5)
+      if (nrow(rv$files_df) == 0 || rv$pdf_index > nrow(rv$files_df)) {
+        return(NULL)
+      }
+
+      img_path <- rv$files_df$Path[rv$pdf_index]
+      if (is.null(img_path) || is.na(img_path) || !file.exists(img_path)) {
+        return(NULL)
+      }
+
+      img <- magick::image_read(img_path)
+      img <- img %>% magick::image_enhance()
+      info <- magick::image_info(img)
+      img_width <- info$width
+      img_height <- info$height
+      img_raster <- as.raster(img)
+
+      par(mar = c(0, 0, 0, 0), xaxs = "i", yaxs = "i")
+      plot(0, 0, type = "n", xlim = c(0, img_width), ylim = c(0, img_height),
+           xlab = "", ylab = "", axes = FALSE, asp = 1)
+      rasterImage(img_raster, 0, 0, img_width, img_height)
+
+      if (ocr_processing()) {
+        rect(10, 10, 300, 50, col = "black", border = NA)
+        text(150, 30, "OCR Processing...", col = "white", cex = 1.5)
+      }
+
+      if (input$ocr_display_mode != "none" && !is.null(rv$ocr_text[[rv$pdf_index]])) {
+        ocr_df <- rv$ocr_text[[rv$pdf_index]]
+        if (nrow(ocr_df) > 0) {
+          ocr_df <- ocr_df[ocr_df$confidence >= input$confidence_threshold, , drop = FALSE]
         }
-        
-        # Draw OCR overlay if in OCR mode and OCR data exists
-        if (input$ocr_display_mode != "none" && !is.null(rv$ocr_text[[rv$pdf_index]])) {
-          ocr_df <- rv$ocr_text[[rv$pdf_index]]
-          
-          # Filter by confidence threshold
-          if (nrow(ocr_df) > 0) {
-            ocr_df <- ocr_df[ocr_df$confidence >= input$confidence_threshold, , drop = FALSE]
-          }
-          
-          # Draw OCR boxes or text
-          if (nrow(ocr_df) > 0) {
-            for (i in seq_len(nrow(ocr_df))) {
-              tryCatch({
-                # Parse bbox coordinates and convert to plot coordinates
-                bbox <- strsplit(ocr_df$bbox[i], ",")[[1]]
-                if (length(bbox) == 4) {
-                  coords <- as.numeric(bbox)
-                  
-                  # Handle coordinate conversion correctly
-                  # Tesseract coordinates: (left, top, right, bottom) with origin at top-left
-                  # Plot coordinates: (left, bottom, right, top) with origin at bottom-left
-                  x1 <- coords[1]  # left
-                  y1 <- img_height - coords[4]  # bottom (inverted)
-                  x2 <- coords[3]  # right
-                  y2 <- img_height - coords[2]  # top (inverted)
-                  
-                  
-                  # Draw rectangle and/or text based on display mode
-                  if (input$ocr_display_mode == "text") {
-                    # Draw background for text
-                    rect(x1, y1, x2, y2, 
-                         col = rgb(1, 1, 1, 0.7), # semi-transparent white
-                         border = "darkgray", 
-                         lwd = 1)
-                    
-                    # Draw word on top
-                    text_x <- (x1 + x2) / 2
-                    text_y <- (y1 + y2) / 2
-                    text(text_x, text_y, 
-                         ocr_df$word[i],
-                         cex = 0.9, 
-                         col = "black", 
-                         font = 2)
-                  } else if (input$ocr_display_mode == "highlight") {
-                    # Draw highlight rectangle
-                    rect(x1, y1, x2, y2, 
-                         col = rgb(0, 0.48, 1, 0.3),  # Semi-transparent blue
-                         border = rgb(0, 0.48, 1, 0.8),  # Solid blue border
-                         lwd = 1)
-                  }
+
+        if (nrow(ocr_df) > 0) {
+          for (i in seq_len(nrow(ocr_df))) {
+            tryCatch({
+              bbox <- strsplit(ocr_df$bbox[i], ",")[[1]]
+              if (length(bbox) == 4) {
+                coords <- as.numeric(bbox)
+                x1 <- coords[1]
+                y1 <- img_height - coords[4]
+                x2 <- coords[3]
+                y2 <- img_height - coords[2]
+
+                if (input$ocr_display_mode == "text") {
+                  rect(x1, y1, x2, y2,
+                       col = rgb(1, 1, 1, 0.7),
+                       border = "darkgray",
+                       lwd = 1)
+                  text_x <- (x1 + x2) / 2
+                  text_y <- (y1 + y2) / 2
+                  text(text_x, text_y,
+                       ocr_df$word[i],
+                       cex = 0.9,
+                       col = "black",
+                       font = 2)
+                } else if (input$ocr_display_mode == "highlight") {
+                  rect(x1, y1, x2, y2,
+                       col = rgb(0, 0.48, 1, 0.3),
+                       border = rgb(0, 0.48, 1, 0.8),
+                       lwd = 1)
                 }
-              }, error = function(e) {
-                # Silently ignore errors in drawing individual words
-              })
-            }
-          } else {
-            # Show message if no text meets confidence threshold
-            text_width <- strwidth("No OCR text meets confidence threshold") * 1.2
-            rect(img_width/2 - text_width/2, img_height/2 - 15, 
-                 img_width/2 + text_width/2, img_height/2 + 15,
-                 col = "white", border = "black")
-            
-            text(img_width/2, img_height/2,
-                 paste("No OCR text meets confidence threshold (", input$confidence_threshold, "%)"),
-                 cex = 1, col = "red")
+              }
+            }, error = function(e) {})
           }
+        } else {
+          text_width <- strwidth("No OCR text meets confidence threshold") * 1.2
+          rect(img_width/2 - text_width/2, img_height/2 - 15,
+               img_width/2 + text_width/2, img_height/2 + 15,
+               col = "white", border = "black")
+          text(img_width/2, img_height/2,
+               paste("No OCR text meets confidence threshold (", input$confidence_threshold, "%)"),
+               cex = 1, col = "red")
         }
-        
-        # Draw user-defined redaction rectangles
-        if (!is.null(rv$rectangles[[img_path]]) && length(rv$rectangles[[img_path]]) > 0) {
-          for (rect_data in rv$rectangles[[img_path]]) {
-            rect(rect_data$xmin, rect_data$ymin, rect_data$xmax, rect_data$ymax,
-                 col = adjustcolor(rect_data$color, alpha.f = 0.3),
-                 border = rect_data$color,
-                 lwd = 2)
-          }
+      }
+
+      current_rectangles <- rv$rectangles[[img_path]]
+      if (!is.null(current_rectangles) && length(current_rectangles) > 0) {
+        for (rect_data in current_rectangles) {
+          rect(rect_data$xmin, rect_data$ymin, rect_data$xmax, rect_data$ymax,
+               col = adjustcolor(rect_data$color, alpha.f = 0.3),
+               border = rect_data$color,
+               lwd = 2)
         }
-      }, res = 96)  # Increased resolution for better text rendering
-    })
-    
+      }
+    }, res = 96)
+
     # Observer for brush selection to extract text
     observeEvent(input$pdf_brush, {
       req(input$pdf_brush)
@@ -1523,28 +1499,15 @@ simplerIndex <- function(id) {
           }
         }
       }
-    )
-    
-    
-    # Also update the rendering function to show file-specific rectangles
+      )
+
     observe({
       if (is.null(rv$files_df) || nrow(rv$files_df) == 0 || is.null(rv$pdf_index) ||
           rv$pdf_index > nrow(rv$files_df)) {
         output$pdf_viewer <- renderUI(NULL)
         return()
       }
-      
-      # Get required values
-      current_ocr_mode <- input$ocr_display_mode
-      current_confidence <- input$confidence_threshold
-      file_path <- rv$files_df$Path[rv$pdf_index]
-      # Use rectangles for this file path
-      current_rectangles <- rv$rectangles[[file_path]]
-      is_processing <- ocr_processing()
-      
-      plot_id <- paste0("pdf_plot_", rv$pdf_index)
-      
-      # Ensure that brush state is correctly reflected in UI when pdf_index changes
+
       isolate({
         if (brush_enabled()) {
           shinyjs::runjs(sprintf("$('#%s').addClass('btn-active');", ns('brush_select')))
@@ -1552,7 +1515,7 @@ simplerIndex <- function(id) {
           shinyjs::runjs(sprintf("$('#%s').removeClass('btn-active');", ns('brush_select')))
         }
       })
-      
+
       output$pdf_viewer <- renderUI({
         img_path <- rv$files_df$Path[rv$pdf_index]
         if (is.null(img_path) || is.na(img_path) || !nzchar(img_path) || !file.exists(img_path)) {
@@ -1568,7 +1531,7 @@ simplerIndex <- function(id) {
         tags$div(
           style = "width: 100%; overflow: auto;",
           plotOutput(
-            outputId = ns(plot_id),  # Namespaced id here because we're creating the element
+            outputId = ns("pdf_plot"),
             width = paste0(display_width, "px"),
             height = paste0(display_height, "px"),
             brush = if (brush_enabled()) {
@@ -1585,75 +1548,9 @@ simplerIndex <- function(id) {
           )
         )
       })
-      
-      output[[plot_id]] <- renderPlot({
-        print("Rendering plot within observer")
-        img_path <- rv$files_df$Path[rv$pdf_index]
-        if (is.null(img_path) || is.na(img_path) || !file.exists(img_path)) {
-          return(NULL)
-        }
-        img <- magick::image_read(img_path)
-        img <- img %>% magick::image_enhance()
-        info <- magick::image_info(img)
-        img_width <- info$width
-        img_height <- info$height
-        img_raster <- as.raster(img)
-        par(mar = c(0, 0, 0, 0), xaxs = "i", yaxs = "i")
-        plot(0, 0, type = "n", xlim = c(0, img_width), ylim = c(0, img_height),
-             xlab = "", ylab = "", axes = FALSE, asp = 1)
-        rasterImage(img_raster, 0, 0, img_width, img_height)
-        if (is_processing) {
-          rect(10, 10, 300, 50, col = "black", border = NA)
-          text(150, 30, "OCR Processing...", col = "white", cex = 1.5)
-        }
-        if (current_ocr_mode != "none" && !is.null(rv$ocr_text[[rv$pdf_index]])) {
-          ocr_df <- rv$ocr_text[[rv$pdf_index]]
-          if (nrow(ocr_df) > 0) {
-            ocr_df <- ocr_df[ocr_df$confidence >= current_confidence, , drop = FALSE]
-          }
-          if (nrow(ocr_df) > 0) {
-            for (i in seq_len(nrow(ocr_df))) {
-              tryCatch({
-                coords <- as.numeric(strsplit(ocr_df$bbox[i], ",")[[1]])
-                if (length(coords) == 4) {
-                  x1 <- coords[1]
-                  y1 <- img_height - coords[4]
-                  x2 <- coords[3]
-                  y2 <- img_height - coords[2]
-                  if (current_ocr_mode == "text") {
-                    rect(x1, y1, x2, y2, col = "white", border = "black", lwd = 1)
-                    text((x1 + x2) / 2, (y1 + y2) / 2, ocr_df$word[i],
-                         cex = 1.2, col = "black", font = 2)
-                  } else {
-                    rect(x1, y1, x2, y2, col = rgb(0, 0.48, 1, 0.3),
-                         border = rgb(0, 0.48, 1, 0.8), lwd = 1)
-                  }
-                }
-              }, error = function(e) {})
-            }
-          } else if (current_ocr_mode != "none") {
-            rect(img_width/2 - 200, img_height/2 - 25, img_width/2 + 200, img_height/2 + 25,
-                 col = "white", border = "black")
-            text(img_width/2, img_height/2,
-                 paste("No OCR text meets confidence threshold (", current_confidence, "%)"),
-                 cex = 1.2, col = "red")
-          }
-        }
-        # Draw user-defined rectangles for this specific file
-        if (!is.null(current_rectangles) && length(current_rectangles) > 0) {
-          for (rect in current_rectangles) {
-            rect(rect$xmin, rect$ymin, rect$xmax, rect$ymax,
-                 col = adjustcolor(rect$color, alpha.f = 0.3),
-                 border = rect$color,
-                 lwd = 2)
-          }
-        }
-      }, res = 50)
     })
-    
-    
-    
-    # Observer to track clicks in the right panel inputs
+
+      # Observer to track clicks in the right panel inputs
     observe({
       # Get all inputs with "_clicked" suffix
       all_inputs <- names(reactiveValuesToList(input))


### PR DESCRIPTION
## Summary
- consolidate plot rendering into a single `pdf_plot` output that handles OCR overlays and redaction rectangles
- update viewer observer to reference the static `pdf_plot` id while keeping brush state

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_b_68b3d2514b2c832fa9cdb09dcd705f54