### PR TITLE
Expose password change module to read-only users

### DIFF
--- a/inst/apps/YGwater/YGwater_globals.R
+++ b/inst/apps/YGwater/YGwater_globals.R
@@ -60,7 +60,6 @@ YGwater_globals <- function(dbName, dbHost, dbPort, dbUser, dbPass, RLS_user, RL
     source(system.file("apps/YGwater/modules/admin/applicationTasks/manageNewsContent.R", package = "YGwater"))
     source(system.file("apps/YGwater/modules/admin/applicationTasks/viewFeedback.R", package = "YGwater"))
     source(system.file("apps/YGwater/modules/admin/users/manageUsers.R", package = "YGwater"))
-    source(system.file("apps/YGwater/modules/admin/users/changePassword.R", package = "YGwater"))
     
     # confirm G drive access for FOD reports
     g_drive <- dir.exists("//env-fs/env-data/corp/water/Hydrology/03_Reporting/Conditions/tabular_internal_reports/")
@@ -70,6 +69,9 @@ YGwater_globals <- function(dbName, dbHost, dbPort, dbUser, dbPass, RLS_user, RL
       source(system.file("apps/YGwater/modules/client/FOD/FOD_main.R", package = "YGwater"))
     }
   }
+
+  # Password change module is available to all users
+  source(system.file("apps/YGwater/modules/admin/users/changePassword.R", package = "YGwater"))
   
   
   # 'client' side modules #####

--- a/inst/apps/YGwater/server.R
+++ b/inst/apps/YGwater/server.R
@@ -118,6 +118,8 @@ app_server <- function(input, output, session) {
   # Hide all 'admin' side tabs if they were generated
   if (!config$public) { # Immediately run the showAdmin function to hide the admin tabs, they're only shown upon login
     showAdmin(show = FALSE)
+  } else {
+    nav_hide(id = "navbar", target = "changePwd")
   }
   
   # Bookmarking and browser history navigation -------------------------------
@@ -616,6 +618,7 @@ $(document).keyup(function(event) {
         # change the 'Login' button to 'Logout'
         shinyjs::hide("loginBtn")
         shinyjs::show("logoutBtn")
+        nav_show(id = "navbar", target = "changePwd")
         
         # Initialize a fresh cache environment for the session
         session$userData$app_cache <- new.env(parent = emptyenv())
@@ -689,6 +692,7 @@ $(document).keyup(function(event) {
     session$userData$config$dbPass <- config$dbPass
     
     showAdmin(show = FALSE, logout = TRUE) # Hide admin tabs and remove logout button
+    nav_hide(id = "navbar", target = "changePwd")
     
     # Clear the app_cache environment
     session$userData$app_cache <- new.env(parent = emptyenv())

--- a/inst/apps/YGwater/ui.R
+++ b/inst/apps/YGwater/ui.R
@@ -272,6 +272,10 @@ app_ui <- function(request) {
                              value = "viewFeedback",
                              uiOutput("viewFeedback_ui"))
           )
+        } else {
+          nav_panel(title = uiOutput("changePwdNavTitle"),
+                    value = "changePwd",
+                    uiOutput("changePwd_ui"))
         },
         # The nav_spacer() and nav_item below are used to have an actionButton to toggle language. If the app gets more than one language, comment this and related elements out and uncomment the code in the HTML script at the bottom of this file that adds a drop-down menu instead.
         nav_spacer(),


### PR DESCRIPTION
## Summary
- Always load the password change module and expose it in the UI for public (read-only) sessions.
- Show the change-password tab to all users after login and hide it on logout.

## Testing
- No tests were run due to user instructions.


------
https://chatgpt.com/codex/tasks/task_b_68b879986530832f9a1d58787e271b08