### PR TITLE
refactor: streamline simplerIndex module

### DIFF
--- a/inst/apps/YGwater/modules/admin/boreholes_wells/ocr_helpers.R
+++ b/inst/apps/YGwater/modules/admin/boreholes_wells/ocr_helpers.R
@@ -1,0 +1,67 @@
+concat_ocr_words_by_row <- function(ocr_df) {
+  if (is.null(ocr_df) || nrow(ocr_df) == 0) return(character(0))
+  coords <- do.call(rbind, lapply(ocr_df$bbox, function(b) as.numeric(strsplit(b, ",")[[1]])))
+  ymin <- coords[,2]
+  ymax <- coords[,4]
+  words <- ocr_df$word
+
+  result <- character(0)
+  current_line <- ""
+  prev_ymin <- ymin[1]
+  prev_ymax <- ymax[1]
+
+  for (i in seq_along(words)) {
+    if (i == 1) {
+      current_line <- words[i]
+    } else {
+      if (ymax[i] < prev_ymin) {
+        result <- c(result, current_line)
+        current_line <- words[i]
+      } else {
+        current_line <- paste(current_line, words[i], sep = " ")
+      }
+      prev_ymin <- ymin[i]
+      prev_ymax <- ymax[i]
+    }
+  }
+  result <- c(result, current_line)
+  return(result)
+}
+
+filter_ocr_noise <- function(ocr_df) {
+  if (is.null(ocr_df) || nrow(ocr_df) == 0) return(ocr_df)
+
+  noise_patterns <- c(
+    "^$", "^\\s*$", "^\\s+$",
+    "^-+$", "^=+$", "^\\|+$", "^_+$", "^\\++$", "^\\*+$", "^#+$", "^~+$", "^`+$", "^'+$", '^"+$', "^\\^+$", "^&+$", "^%+$", "^@+$", "^\\$+$",
+    "^[\\|Il1]{1,3}$", "^[oO0]{1,2}$", "^[cC]{1}$", "^[rR]{1}$", "^[nN]{1}$", "^[mM]{1}$", "^[uU]{1}$", "^[vV]{1}$", "^[wW]{1}$", "^[iI]{1,2}$",
+    "^([a-zA-Z])\\1{3,}$",
+    "^[[:punct:]]+$",
+    "^[a-zA-Z]{1}[0-9]{1}$", "^[0-9]{1}[a-zA-Z]{1}$",
+    "^\\.[a-zA-Z]{1,2}$", "^[a-zA-Z]{1,2}\\.$", "^[()\\[\\]\\{\\}]+$"
+  )
+
+  meaningful_single_chars <- c("A", "a", "O", "o")
+  keep_word <- rep(TRUE, nrow(ocr_df))
+
+  keep_word <- keep_word & !is.na(ocr_df$word) &
+    ocr_df$word != "" &
+    trimws(ocr_df$word) != ""
+
+  for (pattern in noise_patterns) {
+    keep_word <- keep_word & !grepl(pattern, ocr_df$word, perl = TRUE)
+  }
+
+  short_and_meaningless <- nchar(trimws(ocr_df$word)) == 1 &
+    !trimws(ocr_df$word) %in% meaningful_single_chars &
+    !grepl("^[0-9]$", trimws(ocr_df$word))
+
+  keep_word <- keep_word & !short_and_meaningless
+
+  low_conf_short <- ocr_df$confidence < 30 & nchar(trimws(ocr_df$word)) <= 2
+  keep_word <- keep_word & !low_conf_short
+
+  filtered_df <- ocr_df[keep_word, ]
+
+  return(filtered_df)
+}

--- a/inst/apps/YGwater/www/js/sidebar_resize.js
+++ b/inst/apps/YGwater/www/js/sidebar_resize.js
@@ -1,0 +1,62 @@
+function initSidebarResize(opts) {
+  const MIN_LEFT = 140;
+  const MIN_RIGHT = 160;
+  const MIN_MAIN = 300; // keep central workspace usable
+  let resizing = '';
+  let startX = 0;
+  let startWidth = 0;
+  const $body = $('body');
+  const $left = $('#' + opts.leftId);
+  const $right = $('#' + opts.rightId);
+
+  function viewportW(){ return $(window).width(); }
+  function maxLeft(){ return Math.max(MIN_LEFT, viewportW() - $right.outerWidth() - MIN_MAIN); }
+  function maxRight(){ return Math.max(MIN_RIGHT, viewportW() - $left.outerWidth() - MIN_MAIN); }
+
+  function startResize(side, e){
+    resizing = side;
+    startX = e.clientX;
+    startWidth = (side === 'left' ? $left.outerWidth() : $right.outerWidth());
+    $body.addClass('resizing-col');
+    e.preventDefault();
+  }
+
+  $('#' + opts.leftHandle).off('.rs').on('mousedown.rs', e => startResize('left', e));
+  $('#' + opts.rightHandle).off('.rs').on('mousedown.rs', e => startResize('right', e));
+
+  $('#' + opts.leftHandle).off('dblclick.rs').on('dblclick.rs', () => $left.css('width', '300px'));
+  $('#' + opts.rightHandle).off('dblclick.rs').on('dblclick.rs', () => $right.css('width', '400px'));
+
+  $(document).off('.rsMove').on('mousemove.rsMove', function(e){
+    if(!resizing) return;
+    if(resizing === 'left'){
+      let w = startWidth + (e.clientX - startX);
+      w = Math.min(maxLeft(), Math.max(MIN_LEFT, w));
+      $left.css('width', w + 'px');
+    } else if(resizing === 'right'){
+      let w = startWidth - (e.clientX - startX);
+      w = Math.min(maxRight(), Math.max(MIN_RIGHT, w));
+      $right.css('width', w + 'px');
+    }
+  });
+
+  $(document).off('.rsUp').on('mouseup.rsUp', function(){
+    if(resizing){
+      resizing = '';
+      $body.removeClass('resizing-col');
+    }
+  });
+
+  $(window).off('.rsWin').on('resize.rsWin', function(){
+    if($left.outerWidth() > maxLeft()) $left.css('width', maxLeft() + 'px');
+    if($right.outerWidth() > maxRight()) $right.css('width', maxRight() + 'px');
+  });
+
+  const ids = opts.ids || [];
+  ids.forEach(id => {
+    $(document).off('focus.rs click.rs', '#' + id)
+               .on('focus.rs click.rs', '#' + id, function(){
+                 Shiny.setInputValue(id + '_clicked', Date.now(), {priority: 'event'});
+               });
+  });
+}


### PR DESCRIPTION
## Summary
- inline CSS and sidebar JS now loaded directly into the simplerIndex module
- introduce `numericInputWithUnits` helper to cut repeated UI code
- refactor selectize initialization and move OCR utilities to a shared helper file

## Testing
- no tests were run


------
https://chatgpt.com/codex/tasks/task_b_68c497442964832f8b001e70b2e418cf