### PR TITLE
Add targeted tests for titleCase and utility helpers

### DIFF
--- a/tests/testthat/test-titleCase.R
+++ b/tests/testthat/test-titleCase.R
@@ -1,0 +1,29 @@
+test_that("titleCase capitalizes English phrases", {
+  expect_equal(
+    titleCase("the quick brown fox jumps over the lazy dog"),
+    "The Quick Brown Fox Jumps Over the Lazy Dog"
+  )
+
+  expect_equal(
+    titleCase("swe data from eccc", language = "en"),
+    "SWE Data from ECCC"
+  )
+})
+
+
+test_that("titleCase applies French-specific rules", {
+  expect_equal(
+    titleCase("l'été à dawson", language = "fr"),
+    "L'Été à Dawson"
+  )
+
+  expect_equal(
+    titleCase("rivière grande", language = "fr"),
+    "Rivière Grande"
+  )
+})
+
+
+test_that("titleCase validates the requested language", {
+  expect_error(titleCase("bonjour", language = "es"), "Language must be either 'en' or 'fr'.")
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,15 @@
+test_that("round_any rounds using the supplied function", {
+  expect_equal(YGwater:::round_any(c(1.1, 1.6), 1), c(1, 2))
+  expect_equal(YGwater:::round_any(5.7, 2, floor), 4)
+  expect_equal(YGwater:::round_any(5.1, 2, ceiling), 6)
+})
+
+
+test_that("iso_period converts numeric hours to ISO 8601 durations", {
+  expect_equal(YGwater:::iso_period(0), "P0DT0H0M0S")
+  expect_equal(YGwater:::iso_period(26.5), "P1DT2H30M0S")
+  expect_equal(
+    YGwater:::iso_period(c(1.5, 50.75)),
+    c("P0DT1H30M0S", "P2DT2H45M0S")
+  )
+})


### PR DESCRIPTION
## Summary
- add unit tests covering English and French capitalization behaviour in `titleCase`
- add regression tests for `round_any` rounding helpers and `iso_period` duration formatting

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_b_68cb9f4e72dc832fbb47d2c000738bc7