### PR TITLE
Fix metadata sanitization return and duplicate name validation

### DIFF
--- a/inst/apps/YGwater/modules/admin/boreholes_wells/simplerIndex.R
+++ b/inst/apps/YGwater/modules/admin/boreholes_wells/simplerIndex.R
@@ -1399,6 +1399,8 @@ simplerIndex <- function(id) {
           }
         }
       }
+
+      sanitized
     }
 
     validate_metadata_for_upload <- function(metadata) {
@@ -1425,7 +1427,7 @@ simplerIndex <- function(id) {
         session$userData$AquaCache,
         "SELECT borehole_name FROM boreholes.boreholes WHERE borehole_name = $1;",
         params = list(metadata$name)
-      )$name
+      )$borehole_name
 
       if (length(existing_names) > 0) {
         showNotification(


### PR DESCRIPTION
## Summary
- ensure sanitize_metadata_for_insert returns the sanitized metadata list for uploads
- correct the duplicate-name guard to read the borehole_name column returned by the query

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_b_69054bf6217c832faa416b303e89d956