### PR TITLE
Add legend and cluster toggle to monitoring locations map

### DIFF
--- a/inst/apps/YGwater/translations.csv
+++ b/inst/apps/YGwater/translations.csv
@@ -276,6 +276,9 @@ app_version2,,connected to AquaCache database revision ,connectée à la base de
 app_version3,,revision,révision
 Generic labels,,,
 data_type,direct translation,Data Type,Types de données
+unknown,,Unknown,Inconnu
+cluster_points_label,,Group points into clusters,Regrouper les points en grappes
+location_type_legend,,Location type,Type d’emplacement
 loc,direct translation,Location,Emplacement
 locs,,Locations,Endroits
 loc(s),,Location(s),Emplacement(s)


### PR DESCRIPTION
## Summary
- add a checkbox to toggle clustering of monitoring locations on the map
- symbolize locations by type with accessible marker colours/icons and add a legend
- provide translations for the new cluster toggle, legend title, and unknown type label

## Testing
- not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e23a79f88832f9281e81805b1f3bd)