### PR TITLE
Enhance continuous data imputation admin module

### DIFF
--- a/inst/apps/YGwater/modules/admin/continuousData/imputeMissing.R
+++ b/inst/apps/YGwater/modules/admin/continuousData/imputeMissing.R
@@ -90,24 +90,33 @@ imputeMissing <- function(id) {
     ns <- session$ns
     
     ts_meta <- reactive({
-      dbGetQueryDT(session$userData$AquaCache,
-                   "SELECT timeseries_id, location_name AS location, parameter_name AS parameter, media_type AS media, aggregation_type AS aggregation, recording_rate AS nominal_record_rate FROM continuous.timeseries_metadata_en")
+      dbGetQueryDT(
+        session$userData$AquaCache,
+        paste(
+          "SELECT timeseries_id, location_name AS location, parameter_name AS parameter,",
+          "media_type AS media, aggregation_type AS aggregation, recording_rate,",
+          "latitude, longitude FROM continuous.timeseries_metadata_en"
+        )
+      )
     })
     
     output$ts_table <- DT::renderDT({
-      
+
       # Convert some data types to factors for better filtering in DT
       df <- ts_meta()
-      df$record_rate_minutes <- as.factor(df$record_rate_minutes)
-      df$media <- as.factor(df$media)
-      df$aggregation <- as.factor(df$aggregation)
-      df$parameter <- as.factor(df$parameter)
-      
-      DT::datatable(df, 
+      display <- as.data.frame(df)
+      display$recording_rate <- as.factor(display$recording_rate)
+      display$media <- as.factor(display$media)
+      display$aggregation <- as.factor(display$aggregation)
+      display$parameter <- as.factor(display$parameter)
+      display$latitude <- NULL
+      display$longitude <- NULL
+
+      DT::datatable(display,
                     selection = 'single',
                     options = list(
                       columnDefs = list(
-                        list(targets = 0, 
+                        list(targets = 0,
                              visible = FALSE)),
                       scrollX = TRUE,
                       initComplete = htmlwidgets::JS(
@@ -128,10 +137,16 @@ imputeMissing <- function(id) {
     })
     
     selected_ts <- reactiveVal()
-    
+
     observeEvent(input$ts_table_rows_selected, {
       req(input$ts_table_rows_selected)
-      selected_ts(ts_meta()[input$ts_table_rows_selected, "timeseries_id"])
+      selected_ts(ts_meta()[["timeseries_id"]][[input$ts_table_rows_selected]])
+    })
+
+    selected_meta <- reactive({
+      req(selected_ts())
+      meta <- as.data.frame(ts_meta())
+      meta[meta$timeseries_id == selected_ts(), , drop = FALSE]
     })
     
     ts_plot_pre_task <- ExtendedTask$new(function(df) {
@@ -162,124 +177,350 @@ imputeMissing <- function(id) {
     full_data <- reactiveVal(NULL)
     candidates <- reactiveVal(NULL)
     imputed_data <- reactiveVal(NULL)
-    
-    observeEvent(input$load, {
-      req(selected_ts(), input$start, input$end)
-      query <- sprintf(
-        "SELECT datetime, value FROM continuous.measurements_continuous WHERE timeseries_id = %s AND datetime >= '%s' AND datetime <= '%s'",
-        selected_ts(), input$start, input$end
-      )
-      df <- DBI::dbGetQuery(session$userData$AquaCache, query)
-      df$datetime <- as.POSIXct(df$datetime, tz = 'UTC')
-      raw_data(df)
-      if (nrow(df) > 1) {
-        period <- stats::median(diff(df$datetime))
-      } else {
-        period <- 3600
+
+    parse_datetime <- function(x) {
+      if (is.null(x) || !nzchar(x)) {
+        return(NA_real_)
       }
-      full_dt <- data.frame(datetime = seq(min(df$datetime, na.rm = TRUE), max(df$datetime, na.rm = TRUE), by = period))
-      full_dt <- merge(full_dt, df, by = 'datetime', all.x = TRUE)
-      full_data(full_dt)
-      loc <- ts_meta()[input$ts_table_rows_selected, 'location']
-      param <- ts_meta()[input$ts_table_rows_selected, 'parameter']
-      cand_q <- sprintf(
-        "SELECT timeseries_id, location_name AS location, parameter_name AS parameter FROM continuous.timeseries_metadata_en WHERE parameter_name = '%s' AND location_name != '%s'",
-        param, loc
+      parsed <- suppressWarnings(as.POSIXct(x, tz = "UTC"))
+      if (is.na(parsed)) {
+        return(NA_real_)
+      }
+      parsed
+    }
+
+    record_rate_seconds <- function(rate) {
+      if (is.null(rate) || is.na(rate) || !nzchar(rate)) {
+        return(NA_real_)
+      }
+      suppressWarnings(
+        tryCatch(
+          lubridate::period_to_seconds(lubridate::period(rate)),
+          error = function(e) NA_real_
+        )
       )
-      candidates(DBI::dbGetQuery(session$userData$AquaCache, cand_q))
+    }
+
+    haversine_km <- function(lat1, lon1, lat2, lon2) {
+      if (any(is.na(c(lat1, lon1, lat2, lon2)))) {
+        return(NA_real_)
+      }
+      rad <- pi / 180
+      dlat <- (lat2 - lat1) * rad
+      dlon <- (lon2 - lon1) * rad
+      a <- sin(dlat / 2)^2 + cos(lat1 * rad) * cos(lat2 * rad) * sin(dlon / 2)^2
+      c <- 2 * atan2(sqrt(a), sqrt(1 - a))
+      6371 * c
+    }
+
+    fetch_series <- function(tsid, start_dt, end_dt) {
+      con <- session$userData$AquaCache
+      query <- DBI::sqlInterpolate(
+        con,
+        paste(
+          "SELECT datetime, value FROM continuous.measurements_continuous",
+          "WHERE timeseries_id = ?tsid AND datetime >= ?start_dt AND datetime <= ?end_dt",
+          "ORDER BY datetime"
+        ),
+        tsid = tsid,
+        start_dt = start_dt,
+        end_dt = end_dt
+      )
+      res <- DBI::dbGetQuery(con, query)
+      if (nrow(res) > 0) {
+        res$datetime <- as.POSIXct(res$datetime, tz = "UTC")
+        res$value <- as.numeric(res$value)
+      }
+      res
+    }
+
+    observeEvent(input$load, {
+      req(selected_ts())
+      start_dt <- parse_datetime(input$start)
+      end_dt <- parse_datetime(input$end)
+      if (is.na(start_dt) || is.na(end_dt)) {
+        showNotification("Please provide valid start and end datetimes in UTC.", type = "error")
+        return()
+      }
+      if (start_dt >= end_dt) {
+        showNotification("The start datetime must be before the end datetime.", type = "error")
+        return()
+      }
+
+      df <- fetch_series(selected_ts(), start_dt, end_dt)
+      if (nrow(df) == 0) {
+        showNotification("No measurements were found for the selected period.", type = "error")
+        raw_data(NULL)
+        full_data(NULL)
+        imputed_data(NULL)
+        candidates(NULL)
+        return()
+      }
+
+      df <- df[order(df$datetime), ]
+      raw_data(df)
+
+      meta_row <- selected_meta()
+      step <- record_rate_seconds(meta_row$recording_rate[[1]])
+      if (is.na(step) || step <= 0) {
+        if (nrow(df) > 1) {
+          diffs <- diff(df$datetime)
+          step <- stats::median(as.numeric(diffs, units = "secs"))
+        } else {
+          step <- 3600
+        }
+      }
+
+      seq_start <- min(start_dt, min(df$datetime, na.rm = TRUE))
+      seq_end <- max(end_dt, max(df$datetime, na.rm = TRUE))
+      full_dt <- data.frame(
+        datetime = seq(seq_start, seq_end, by = step)
+      )
+      df_full <- merge(full_dt, df, by = "datetime", all.x = TRUE)
+      df_full <- df_full[order(df_full$datetime), ]
+      full_data(df_full)
+      imputed_data(NULL)
+
+      if (input$method == "direct") {
+        meta <- as.data.frame(ts_meta())
+        selected_row <- meta[meta$timeseries_id == selected_ts(), , drop = FALSE]
+        if (nrow(selected_row) > 0) {
+          meta <- meta[meta$timeseries_id != selected_ts(), , drop = FALSE]
+          meta <- meta[meta$parameter == selected_row$parameter, , drop = FALSE]
+          meta$distance_km <- mapply(
+            haversine_km,
+            selected_row$latitude[[1]],
+            selected_row$longitude[[1]],
+            meta$latitude,
+            meta$longitude
+          )
+          meta <- meta[is.na(meta$distance_km) | meta$distance_km <= input$radius, , drop = FALSE]
+          meta <- meta[order(meta$distance_km), ]
+          candidates(meta[, c("timeseries_id", "location", "parameter", "recording_rate", "distance_km")])
+        } else {
+          candidates(NULL)
+        }
+      } else {
+        candidates(NULL)
+      }
     })
+
+    observeEvent({
+      list(full_data(), input$radius, input$method)
+    }, {
+      if (is.null(full_data()) || input$method != "direct") {
+        candidates(NULL)
+        return()
+      }
+      meta <- as.data.frame(ts_meta())
+      selected_row <- meta[meta$timeseries_id == selected_ts(), , drop = FALSE]
+      if (nrow(selected_row) == 0) {
+        candidates(NULL)
+        return()
+      }
+      meta <- meta[meta$timeseries_id != selected_ts(), , drop = FALSE]
+      meta <- meta[meta$parameter == selected_row$parameter, , drop = FALSE]
+      meta$distance_km <- mapply(
+        haversine_km,
+        selected_row$latitude[[1]],
+        selected_row$longitude[[1]],
+        meta$latitude,
+        meta$longitude
+      )
+      meta <- meta[is.na(meta$distance_km) | meta$distance_km <= input$radius, , drop = FALSE]
+      meta <- meta[order(meta$distance_km), ]
+      if (nrow(meta) == 0) {
+        candidates(NULL)
+      } else {
+        candidates(meta[, c("timeseries_id", "location", "parameter", "recording_rate", "distance_km")])
+      }
+    }, ignoreNULL = FALSE)
     
     output$direct_impute_selection <- renderText({
+      req(input$method == "direct")
+      if (is.null(candidates()) || nrow(candidates()) == 0) {
+        return("No nearby timeseries were found within the selected radius.")
+      }
       "Select a timeseries below to impute missing values using the direct method."
     })
+
     output$candidates <- DT::renderDT({
+      req(input$method == "direct")
       req(candidates())
-      DT::datatable(candidates(), 
-                    selection = 'single', 
-                    options = list(scrollX = TRUE),
-                    filter = 'top')
+      DT::datatable(
+        candidates(),
+        selection = "single",
+        options = list(scrollX = TRUE),
+        filter = "top",
+        rownames = FALSE
+      )
     })
-    
+
     perform_impute <- function(df, method, cand = NULL) {
-      if (method == 'direct' && !is.null(cand)) {
-        df$imputed <- is.na(df$value)
-        merged <- merge(df, cand, by = 'datetime', all.x = TRUE, suffixes = c('', '.cand'))
-        offset <- mean(merged$value - merged$value.cand, na.rm = TRUE)
-        fill_idx <- which(is.na(merged$value))
-        merged$value[fill_idx] <- merged$value.cand[fill_idx] + offset
-        df$value <- merged$value
+      df <- df[order(df$datetime), ]
+      df$imputed <- FALSE
+      missing_idx <- which(is.na(df$value))
+      if (!length(missing_idx)) {
         return(df)
       }
-      df$imputed <- FALSE
-      na_run <- rle(is.na(df$value))
-      pos <- cumsum(na_run$lengths)
-      for (i in seq_along(na_run$lengths)) {
-        if (na_run$values[i]) {
-          start_pos <- pos[i] - na_run$lengths[i] + 1
-          end_pos <- pos[i + 1] - na_run$lengths[i + 1]
-          if (method == 'linear') {
-            y <- stats::approx(x = c(start_pos - 1, end_pos + 1),
-                               y = df$value[c(start_pos - 1, end_pos + 1)],
-                               xout = start_pos:end_pos)$y
-          } else {
-            y <- stats::spline(x = c(start_pos - 1, end_pos + 1),
-                               y = df$value[c(start_pos - 1, end_pos + 1)],
-                               xout = start_pos:end_pos)$y
-          }
-          df$value[start_pos:end_pos] <- y
-          df$imputed[start_pos:end_pos] <- TRUE
+
+      if (method == "direct") {
+        if (is.null(cand) || nrow(cand) == 0) {
+          return(NULL)
         }
+        cand <- cand[order(cand$datetime), ]
+        names(cand)[names(cand) == "value"] <- "reference_value"
+        merged <- merge(df, cand, by = "datetime", all.x = TRUE)
+        overlap <- !is.na(merged$value) & !is.na(merged$reference_value)
+        if (!any(overlap)) {
+          return(NULL)
+        }
+        offset <- mean(merged$value[overlap] - merged$reference_value[overlap], na.rm = TRUE)
+        fill_idx <- which(is.na(merged$value) & !is.na(merged$reference_value))
+        if (!length(fill_idx)) {
+          return(NULL)
+        }
+        df$value[fill_idx] <- merged$reference_value[fill_idx] + offset
+        df$imputed[fill_idx] <- TRUE
+        return(df)
       }
+
+      available <- which(!is.na(df$value))
+      if (method == "linear" && length(available) < 2) {
+        return(NULL)
+      }
+      if (method == "spline" && length(available) < 3) {
+        return(NULL)
+      }
+
+      x <- as.numeric(df$datetime[available])
+      y <- df$value[available]
+      xout <- as.numeric(df$datetime)
+      if (method == "linear") {
+        interp <- stats::approx(x = x, y = y, xout = xout, rule = 1)$y
+      } else {
+        interp <- stats::spline(x = x, y = y, xout = xout, method = "natural")$y
+      }
+      filled_idx <- missing_idx[!is.na(interp[missing_idx])]
+      if (!length(filled_idx)) {
+        return(NULL)
+      }
+      df$value[filled_idx] <- interp[filled_idx]
+      df$imputed[filled_idx] <- TRUE
       df
     }
-    
+
     observeEvent(input$impute, {
       req(full_data())
-      df <- full_data()
       method <- input$method
-      if (method == 'direct') {
+      df <- full_data()
+      if (method == "direct") {
         sel <- input$candidates_rows_selected
         if (length(sel) != 1) {
-          showNotification('Select a timeseries for direct imputation.', type = 'error')
+          showNotification("Select a timeseries for direct imputation.", type = "error")
           return()
         }
-        tsid2 <- candidates()[sel, 'timeseries_id']
-        q <- sprintf(
-          "SELECT datetime, value FROM continuous.measurements_continuous WHERE timeseries_id = %s AND datetime >= '%s' AND datetime <= '%s'",
-          tsid2, min(df$datetime, na.rm = TRUE), max(df$datetime, na.rm = TRUE)
-        )
-        cand <- DBI::dbGetQuery(session$userData$AquaCache, q)
-        cand$datetime <- as.POSIXct(cand$datetime, tz = 'UTC')
-        cand_full <- merge(data.frame(datetime = df$datetime), cand, by = 'datetime', all.x = TRUE)
-        imp <- perform_impute(df, 'direct', cand_full)
+        ref_meta <- candidates()
+        if (is.null(ref_meta) || nrow(ref_meta) < sel) {
+          showNotification("Unable to determine the selected timeseries.", type = "error")
+          return()
+        }
+        tsid2 <- ref_meta[sel, "timeseries_id"]
+        ref_df <- fetch_series(tsid2, min(df$datetime), max(df$datetime))
+        if (nrow(ref_df) == 0) {
+          showNotification("The selected reference timeseries has no data in the requested period.", type = "error")
+          return()
+        }
+        ref_full <- merge(data.frame(datetime = df$datetime), ref_df, by = "datetime", all.x = TRUE)
+        imp <- perform_impute(df, "direct", ref_full)
+        if (is.null(imp)) {
+          showNotification("Unable to impute values with the selected timeseries. Ensure there is overlapping data to compute an offset.", type = "error")
+          return()
+        }
       } else {
         imp <- perform_impute(df, method)
+        if (is.null(imp)) {
+          if (method == "linear") {
+            showNotification("At least two existing measurements are required for linear interpolation.", type = "error")
+          } else {
+            showNotification("At least three existing measurements are required for spline interpolation.", type = "error")
+          }
+          return()
+        }
+      }
+
+      if (!any(imp$imputed)) {
+        showNotification("No missing values met the criteria for imputation.", type = "warning")
       }
       imputed_data(imp)
-      output$plot <- plotly::renderPlotly({
-        dat <- imp
-        dat$existing <- dat$value
-        dat$existing[dat$imputed] <- NA
-        dat$impute <- imp$value
-        dat$impute[!imp$imputed] <- NA
-        plotly::plot_ly() %>%
-          plotly::add_lines(data = dat, x = ~datetime, y = ~existing, name = 'existing', line = list(color = 'blue')) %>%
-          plotly::add_lines(data = dat, x = ~datetime, y = ~impute, name = 'imputed', line = list(color = 'red'))
-      })
     })
-    
+
+    output$plot <- plotly::renderPlotly({
+      req(imputed_data())
+      df <- imputed_data()
+      existing <- df
+      existing$value[df$imputed] <- NA
+      imputed_only <- df
+      imputed_only$value[!df$imputed] <- NA
+      plotly::plot_ly() %>%
+        plotly::add_lines(
+          data = existing,
+          x = ~datetime,
+          y = ~value,
+          name = "Existing",
+          line = list(color = "#0072B2")
+        ) %>%
+        plotly::add_markers(
+          data = existing,
+          x = ~datetime,
+          y = ~value,
+          name = "Existing",
+          marker = list(color = "#0072B2", size = 4),
+          showlegend = FALSE
+        ) %>%
+        plotly::add_lines(
+          data = imputed_only,
+          x = ~datetime,
+          y = ~value,
+          name = "Imputed",
+          line = list(color = "#D55E00")
+        ) %>%
+        plotly::add_markers(
+          data = imputed_only,
+          x = ~datetime,
+          y = ~value,
+          name = "Imputed",
+          marker = list(color = "#D55E00", size = 6)
+        ) %>%
+        plotly::layout(xaxis = list(title = "Datetime"), yaxis = list(title = "Value"))
+    })
+
     observeEvent(input$commit, {
       req(imputed_data())
-      tryCatch({
-        df <- imputed_data()
-        to_push <- df[df$imputed, c('datetime', 'value')]
-        to_push$timeseries_id <- selected_ts()
-        to_push$imputed <- TRUE
-        AquaCache::addNewContinuous(tsid = selected_ts(), df = to_push, con = session$userData$AquaCache)
-        showNotification('Data imputed and saved.', type = 'message')
-      }, error = function(e) {
-        showNotification(paste('Commit failed:', e$message), type = 'error')
-      })
+      df <- imputed_data()
+      to_push <- df[df$imputed, c("datetime", "value")]
+      if (nrow(to_push) == 0) {
+        showNotification("There are no imputed values to commit.", type = "error")
+        return()
+      }
+      to_push$timeseries_id <- selected_ts()
+      to_push$imputed <- TRUE
+
+      tryCatch(
+        {
+          AquaCache::addNewContinuous(
+            tsid = selected_ts(),
+            df = to_push,
+            con = session$userData$AquaCache,
+            target = "realtime",
+            overwrite = "conflict"
+          )
+          showNotification("Imputed values saved to the database.", type = "message")
+        },
+        error = function(e) {
+          showNotification(paste("Commit failed:", e$message), type = "error")
+        }
+      )
     })
   })
 }


### PR DESCRIPTION
## Summary
- extend the impute-missing admin module to load full timeseries slices and nearby candidate metadata from the database
- add helper routines for linear, spline, and offset-based direct imputation along with interactive previews
- gate committing results with validation and reuse AquaCache utilities to write imputed values back to the database

## Testing
- not run (per instructions)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69117022cd58832f8bf9c5056be0aff2)