### PR TITLE
Add table-driven continuous plot module

### DIFF
--- a/inst/apps/YGwater/YGwater_globals.R
+++ b/inst/apps/YGwater/YGwater_globals.R
@@ -184,6 +184,10 @@ YGwater_globals <- function(
     "apps/YGwater/modules/client/plot/continuousPlot.R",
     package = "YGwater"
   ))
+  source(system.file(
+    "apps/YGwater/modules/client/plot/continuousTablePlot.R",
+    package = "YGwater"
+  ))
 
   # Report modules
   if (g_drive) {

--- a/inst/apps/YGwater/modules/client/plot/continuousTablePlot.R
+++ b/inst/apps/YGwater/modules/client/plot/continuousTablePlot.R
@@ -1,0 +1,264 @@
+contTablePlotUI <- function(id) {
+  ns <- NS(id)
+
+  page_sidebar(
+    sidebar = sidebar(
+      title = NULL,
+      width = 350,
+      bg = config$sidebar_bg,
+      open = list(mobile = "always-above"),
+      uiOutput(ns("sidebar"))
+    ),
+    uiOutput(ns("main"))
+  )
+}
+
+contTablePlot <- function(id, language, inputs) {
+  moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+
+    if (session$userData$user_logged_in) {
+      cached <- cont_data.plot_module_data(
+        con = session$userData$AquaCache,
+        env = session$userData$app_cache
+      )
+    } else {
+      cached <- cont_data.plot_module_data(con = session$userData$AquaCache)
+    }
+
+    moduleData <- reactiveValues(
+      locs = cached$locs,
+      sub_locs = cached$sub_locs,
+      params = cached$params,
+      media = cached$media,
+      aggregation_types = cached$aggregation_types,
+      range = cached$range,
+      timeseries = cached$timeseries
+    )
+
+    moduleInputs <- reactiveValues(
+      location_id = if (!is.null(inputs$location_id)) {
+        as.numeric(inputs$location_id)
+      } else {
+        NULL
+      },
+      timeseries_id = if (!is.null(inputs$timeseries_id)) {
+        as.numeric(inputs$timeseries_id)
+      } else {
+        NULL
+      }
+    )
+
+    table_range <- reactive({
+      start_val <- as.Date(moduleData$range$min_datetime)
+      end_val <- as.Date(moduleData$range$max_datetime)
+
+      if (is.na(start_val)) start_val <- Sys.Date() - 365
+      if (is.na(end_val)) end_val <- Sys.Date()
+
+      list(start = start_val, end = end_val)
+    })
+
+    timeseries_table <- reactive({
+      lang <- language$language
+      loc_name_col <- if (lang == "fr") "name_fr" else "name"
+      sub_loc_col <- if (lang == "fr") "sub_location_name_fr" else "sub_location_name"
+      param_col <- if (lang == "fr") "param_name_fr" else "param_name"
+      media_col <- if (lang == "fr") "media_type_fr" else "media_type"
+      agg_col <- if (lang == "fr") "aggregation_type_fr" else "aggregation_type"
+
+      ts <- moduleData$timeseries
+      if (!is.null(input$location_filter) && length(input$location_filter) > 0) {
+        ts <- ts[ts$location_id %in% as.numeric(input$location_filter), ]
+      }
+      if (!is.null(input$parameter_filter) && length(input$parameter_filter) > 0) {
+        ts <- ts[ts$parameter_id %in% as.numeric(input$parameter_filter), ]
+      }
+
+      ts |>
+        dplyr::left_join(moduleData$locs, by = "location_id") |>
+        dplyr::left_join(moduleData$sub_locs, by = "sub_location_id") |>
+        dplyr::left_join(moduleData$params, by = "parameter_id") |>
+        dplyr::left_join(moduleData$media, by = "media_id") |>
+        dplyr::left_join(moduleData$aggregation_types, by = "aggregation_type_id") |>
+        dplyr::mutate(
+          record_rate = as.character(lubridate::seconds_to_period(record_rate)),
+          start_date = as.Date(start_datetime),
+          end_date = as.Date(end_datetime)
+        ) |>
+        dplyr::transmute(
+          timeseries_id,
+          location = .data[[loc_name_col]],
+          sub_location = .data[[sub_loc_col]],
+          parameter = .data[[param_col]],
+          media = .data[[media_col]],
+          aggregation = .data[[agg_col]],
+          record_rate,
+          z,
+          start_date,
+          end_date
+        ) |>
+        dplyr::arrange(location, parameter, record_rate)
+    })
+
+    selected_timeseries <- reactiveVal(moduleInputs$timeseries_id)
+
+    observeEvent(language$language, {
+      ts <- timeseries_table()
+      if (is.null(selected_timeseries()) && nrow(ts) > 0) {
+        selected_timeseries(ts$timeseries_id[1])
+      }
+    })
+
+    observeEvent(input$timeseries_table_rows_selected, {
+      ts <- timeseries_table()
+      if (!is.null(input$timeseries_table_rows_selected) &&
+        length(input$timeseries_table_rows_selected) == 1 &&
+        nrow(ts) >= input$timeseries_table_rows_selected) {
+        selected_timeseries(ts$timeseries_id[input$timeseries_table_rows_selected])
+      }
+    })
+
+    observeEvent(timeseries_table(), {
+      ts <- timeseries_table()
+      if (!is.null(moduleInputs$timeseries_id) && moduleInputs$timeseries_id %in% ts$timeseries_id) {
+        selected_timeseries(moduleInputs$timeseries_id)
+        moduleInputs$timeseries_id <- NULL
+      } else if (is.null(selected_timeseries()) && nrow(ts) > 0) {
+        selected_timeseries(ts$timeseries_id[1])
+      }
+    }, ignoreNULL = FALSE)
+
+    output$sidebar <- renderUI({
+      date_range <- table_range()
+      tagList(
+        h4(tr("cont_table_intro", language$language)),
+        selectizeInput(
+          ns("location_filter"),
+          tr("loc(s)", language$language),
+          choices = stats::setNames(moduleData$locs$location_id, moduleData$locs$name),
+          selected = moduleInputs$location_id,
+          multiple = TRUE,
+          options = list(placeholder = tr("select_locs", language$language))
+        ),
+        selectizeInput(
+          ns("parameter_filter"),
+          tr("parameters", language$language),
+          choices = stats::setNames(moduleData$params$parameter_id, moduleData$params$param_name),
+          multiple = TRUE,
+          options = list(placeholder = tr("select_params", language$language))
+        ),
+        dateRangeInput(
+          ns("date_range"),
+          tr("date_range_lab", language$language),
+          start = date_range$start,
+          end = date_range$end,
+          format = "yyyy-mm-dd",
+          startview = "month",
+          min = date_range$start,
+          max = date_range$end,
+          language = language$abbrev,
+          separator = tr("date_sep", language$language)
+        ),
+        checkboxInput(
+          ns("show_hist"),
+          tr("plot_hist_range", language$language),
+          value = TRUE
+        ),
+        checkboxInput(
+          ns("show_unusable"),
+          tr("plot_show_unusable", language$language),
+          value = FALSE
+        ),
+        checkboxInput(
+          ns("show_grades"),
+          tr("plot_show_grades", language$language),
+          value = FALSE
+        ),
+        checkboxInput(
+          ns("show_approvals"),
+          tr("plot_show_approvals", language$language),
+          value = FALSE
+        ),
+        checkboxInput(
+          ns("show_qualifiers"),
+          tr("plot_show_qualifiers", language$language),
+          value = FALSE
+        )
+      )
+    })
+
+    output$main <- renderUI({
+      tagList(
+        h4(tr("cont_table_heading", language$language)),
+        div(
+          class = "mb-3",
+          DT::dataTableOutput(ns("timeseries_table"))
+        ),
+        h4(tr("cont_table_plot_heading", language$language)),
+        plotly::plotlyOutput(ns("timeseries_plot"), height = "600px")
+      )
+    })
+
+    output$timeseries_table <- DT::renderDataTable({
+      ts <- timeseries_table()
+      selected_row <- NULL
+      if (!is.null(selected_timeseries())) {
+        selected_row <- which(ts$timeseries_id == selected_timeseries())
+        if (length(selected_row) == 0) {
+          selected_row <- NULL
+        }
+      }
+
+      col_names <- c(
+        tr("cont_table_col_location", language$language),
+        tr("cont_table_col_sub_location", language$language),
+        tr("cont_table_col_parameter", language$language),
+        tr("cont_table_col_media", language$language),
+        tr("cont_table_col_aggregation", language$language),
+        tr("cont_table_col_record_rate", language$language),
+        "z",
+        tr("cont_table_col_start_date", language$language),
+        tr("cont_table_col_end_date", language$language)
+      )
+
+      DT::datatable(
+        ts,
+        rownames = FALSE,
+        selection = list(mode = "single", selected = selected_row),
+        options = list(
+          pageLength = 10,
+          columnDefs = list(list(visible = FALSE, targets = 0)),
+          order = list(list(1, "asc"), list(3, "asc"))
+        ),
+        colnames = c("timeseries_id", col_names)
+      ) |>
+        DT::formatDate(columns = c("start_date", "end_date"), method = "toDateString")
+    })
+
+    output$timeseries_plot <- plotly::renderPlotly({
+      req(input$date_range)
+      req(selected_timeseries())
+
+      tryCatch(
+        {
+          plotTimeseries(
+            timeseries_id = selected_timeseries(),
+            start_date = input$date_range[1],
+            end_date = input$date_range[2],
+            historic_range = input$show_hist,
+            unusable = input$show_unusable,
+            grades = input$show_grades,
+            approvals = input$show_approvals,
+            qualifiers = input$show_qualifiers,
+            lang = language$language,
+            webgl = TRUE
+          )
+        },
+        error = function(e) {
+          validate(need(FALSE, e$message))
+        }
+      )
+    })
+  })
+}

--- a/inst/apps/YGwater/server.R
+++ b/inst/apps/YGwater/server.R
@@ -299,6 +299,7 @@ app_server <- function(input, output, session) {
     ui_loaded$home <- FALSE
     ui_loaded$discPlot <- FALSE
     ui_loaded$contPlot <- FALSE
+    ui_loaded$contTablePlot <- FALSE
     ui_loaded$paramValuesMap <- FALSE
     ui_loaded$rasterValuesMap <- FALSE
     ui_loaded$monitoringLocationsMap <- FALSE
@@ -1241,6 +1242,21 @@ $(document).keyup(function(event) {
         }
       }
     }
+    if (input$navbar == "contTablePlot") {
+      if (!ui_loaded$contTablePlot) {
+        output$plotContinuousTable_ui <- renderUI(contTablePlotUI("contTablePlot"))
+        ui_loaded$contTablePlot <- TRUE
+        contTablePlot(
+          "contTablePlot",
+          language = languageSelection,
+          inputs = moduleOutputs$mapLocs
+        )
+        if (!is.null(moduleOutputs$mapLocs)) {
+          moduleOutputs$mapLocs$location_id <- NULL
+          moduleOutputs$mapLocs$change_tab <- NULL
+        }
+      }
+    }
 
     ### Maps nav_menu ##########################
     if (input$navbar == "monitoringLocationsMap") {
@@ -1267,6 +1283,9 @@ $(document).keyup(function(event) {
           }
           if (target == "contPlot") {
             ui_loaded$contPlot <- FALSE
+          }
+          if (target == "contTablePlot") {
+            ui_loaded$contTablePlot <- FALSE
           }
           nav_select(session = session, "navbar", selected = target) # Change tabs
           moduleOutputs$mapLocs$change_tab <- NULL

--- a/inst/apps/YGwater/translations.csv
+++ b/inst/apps/YGwater/translations.csv
@@ -11,6 +11,7 @@ maps_snowbull,mapsNavSnowbullTitle,Snow bulletin,Bulletin nivométrique
 plots,plotsNavMenuTitle,Plots ,Graphiques
 plots_discrete,plotsNavDiscTitle,Discrete,Discrètes
 plots_continuous,plotsNavContTitle,Continuous,Continues
+plots_continuous_table,plotsNavContTableTitle,Continuous (table),Continues (tableau)
 plots_mix,plotsNavMixTitle,Mixed data,Données mixtes
 reports,reportsNavMenuTitle,Reports,Rapports
 reports_snow,reportsNavSnowstatsTitle,Snowpack statistics,Statistiques nivométriques
@@ -147,6 +148,17 @@ plot_show_unusable,,Show unusable data?,Montrer les données inutilisables?
 plot_show_grades,,Show grades?,Montrer les cotes?
 plot_show_approvals,,Show approval levels?,Montrer les niveaux d'approbations?
 plot_show_qualifiers,,Show qualifiers?,Montrer les qualificatifs?
+cont_table_intro,,Choose a timeseries from the table to plot.,Choisissez une série chronologique à représenter.
+cont_table_heading,,Available timeseries,Séries chronologiques disponibles
+cont_table_plot_heading,,Plot,Graphique
+cont_table_col_location,,Location,Emplacement
+cont_table_col_sub_location,,Sub-location,Sous-emplacement
+cont_table_col_parameter,,Parameter,Paramètre
+cont_table_col_media,,Media,Média
+cont_table_col_aggregation,,Aggregation,Agrégation
+cont_table_col_record_rate,,Record rate,Fréquence d'enregistrement
+cont_table_col_start_date,,Start date,Date de début
+cont_table_col_end_date,,End date,Date de fin
 facet_on,,Split plots by,Diviser les graphiques par
 facet_on_tooltip,,"Creates multiple plots, each showing one location or one parameter. The other variable appears as separate lines or points.","Crée plusieurs graphiques, chacun montrant un seul emplacement ou un seul paramètre. L’autre variable apparaît sous forme de lignes ou de points distincts."
 use_log_scale,,Use logarithmic scale,Utiliser une échelle logarithmique

--- a/inst/apps/YGwater/ui.R
+++ b/inst/apps/YGwater/ui.R
@@ -197,6 +197,11 @@ app_ui <- function(request) {
             title = uiOutput("plotsNavContTitle"),
             value = "contPlot",
             uiOutput("plotContinuous_ui")
+          ),
+          nav_panel(
+            title = uiOutput("plotsNavContTableTitle"),
+            value = "contTablePlot",
+            uiOutput("plotContinuousTable_ui")
           )
         ),
         if (config$g_drive) {


### PR DESCRIPTION
## Summary
- add a new continuous plotting module that lists available timeseries in a selectable table with grade/approval/qualifier toggles
- wire the module into the existing app navigation and module sourcing
- add translations and labels for the new table-based continuous plot entry

## Testing
- Not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69292e5f7158832fb662838d08d2395a)