### PR TITLE
Add URL language override for YGwater app

### DIFF
--- a/inst/apps/YGwater/server.R
+++ b/inst/apps/YGwater/server.R
@@ -271,7 +271,15 @@ app_server <- function(input, output, session) {
     if (!length(params)) {
       return("")
     }
-    paste0("?", httpuv::encodeQueryString(params))
+    encoded <- vapply(
+      names(params),
+      function(name) {
+        value <- params[[name]]
+        paste0(name, "=", utils::URLencode(value, reserved = TRUE))
+      },
+      character(1)
+    )
+    paste0("?", paste(encoded, collapse = "&"))
   }
   get_lang_code <- function() {
     if (is.null(languageSelection$language)) {


### PR DESCRIPTION
### Motivation
- Allow consumers to load the app (or specific module/page) with an explicit language via the URL `lang` query parameter. 
- Ensure URL-driven language selection takes precedence over browser-detected language on initial load.
- Consolidate language-setting logic so toggles and browser detection behave consistently.

### Description
- Added a `language_override` reactive flag and a `set_language_selection` helper to centralize language setup.
- Parse the `lang` query parameter from `session$clientData$url_search` and, if present, set the app language via `set_language_selection` and mark `language_override`.
- Modified the browser-detected language observer (`input$userLang`) to no-op if an explicit URL language override is present, and to call `set_language_selection` otherwise.
- Updated the language toggle (`input$language_button`) to call `set_language_selection` so the same code path is used for all language changes.

### Testing
- No automated tests were run (per repository instructions to avoid running tests/installing R in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695847fbe328832f95fe42d052acbe4f)