### PR TITLE
Fixed date-time and value col selectize inputs when uploading .csv

### DIFF
--- a/inst/apps/YGwater/modules/admin/continuousData/addContData.R
+++ b/inst/apps/YGwater/modules/admin/continuousData/addContData.R
@@ -237,14 +237,14 @@ addContData <- function(id) {
           selectizeInput(
             ns('upload_datetime_col'),
             'Select the column for datetime:',
-            choices = names(df),
-            selected = names(df)[1]
+            choices = names(data$upload_raw),
+            selected = names(data$upload_raw)[1]
           ),
           selectizeInput(
             ns('upload_value_col'),
             'Select the column for value:',
-            choices = names(df),
-            selected = names(df)[2]
+            choices = names(data$upload_raw),
+            selected = names(data$upload_raw)[2]
           ),
           easyClose = FALSE,
           footer = tagList(


### PR DESCRIPTION
Modified addContData's server such that, when uploading a .csv or .xlsx file with non-standard structure, the date-time and value column `selectizeInputs` within the displayed modal are populated with the column names from the uploaded file.  Previously, these `selectizeInputs` were blank.