### PR TITLE
Fixed bug in which uploading timeseries data from .xlsx, .csv didn't work

### DIFF
--- a/inst/apps/YGwater/modules/admin/continuousData/addContData.R
+++ b/inst/apps/YGwater/modules/admin/continuousData/addContData.R
@@ -263,10 +263,10 @@ addContData <- function(id) {
       input$confirm_mapping,
       {
         removeModal() # Close the modal dialog
-        req(input$datetime_col, input$value_col)
+        req(input$upload_datetime_col, input$upload_value_col)
         df_mapped <- data.frame(
-          datetime = data$upload_raw[[input$datetime_col]],
-          value = data$upload_raw[[input$value_col]]
+          datetime = data$upload_raw[[input$upload_datetime_col]],
+          value = data$upload_raw[[input$upload_value_col]]
         )
         data$df <- df_mapped
       },


### PR DESCRIPTION
req conditions weren't met causing some logic not to fire: `upload_datetime_col` and `upload_value_col` were referred to as `datetime_col` and `value_col` in `req()`