### PR TITLE
Fixed 2 bugs in manageUsers, one trailing comma, and one quoted keyword

### DIFF
--- a/inst/apps/YGwater/modules/admin/users/manageUsers.R
+++ b/inst/apps/YGwater/modules/admin/users/manageUsers.R
@@ -236,7 +236,7 @@ WHERE schema_name NOT LIKE 'pg_%'
                 DBI::dbQuoteIdentifier(
                   session$userData$AquaCache,
                   input$group_name
-                ),
+                )
               )
               DBI::dbExecute(
                 session$userData$AquaCache,
@@ -253,10 +253,7 @@ WHERE schema_name NOT LIKE 'pg_%'
                   for (schema in input$schema_permissions) {
                     sql <- sprintf(
                       "GRANT %s ON ALL TABLES IN SCHEMA %s TO %s",
-                      DBI::dbQuoteIdentifier(
-                        session$userData$AquaCache,
-                        permission
-                      ),
+                      permission,
                       DBI::dbQuoteIdentifier(
                         session$userData$AquaCache,
                         schema


### PR DESCRIPTION
Two issues causing create groups action to fail.  

1. Trailing comma causing an `argument missing with no default error` R error.

2.`DBI::dbQuoteIdentifier()` wrapped permission when constructing SQL to grant table permissions causing `unknown permission` sql error.  Permissions are keywords and should not be quoted.

