### PR TITLE
Add admin module to manage application notifications

### DIFF
--- a/inst/apps/YGwater/YGwater_globals.R
+++ b/inst/apps/YGwater/YGwater_globals.R
@@ -150,6 +150,10 @@ YGwater_globals <- function(
       package = "YGwater"
     ))
     source(system.file(
+      "apps/YGwater/modules/admin/applicationTasks/manageNotifications.R",
+      package = "YGwater"
+    ))
+    source(system.file(
       "apps/YGwater/modules/admin/applicationTasks/viewFeedback.R",
       package = "YGwater"
     ))

--- a/inst/apps/YGwater/modules/admin/applicationTasks/manageNotifications.R
+++ b/inst/apps/YGwater/modules/admin/applicationTasks/manageNotifications.R
@@ -1,0 +1,301 @@
+manageNotificationsUI <- function(id, module_choices) {
+  ns <- NS(id)
+  page_fluid(
+    tagList(
+      tags$p(
+        "Notifications appear in modules by server name. Use 'all' to show a",
+        "notification across the entire application."
+      ),
+      DT::DTOutput(ns("notifications_table")),
+      tags$hr(),
+      checkboxInput(ns("active"), "Active", value = TRUE),
+      selectizeInput(
+        ns("target_module"),
+        "Target modules",
+        choices = module_choices,
+        multiple = TRUE,
+        selected = "all"
+      ),
+      textAreaInput(
+        ns("message_en"),
+        "Message (English)",
+        width = "100%",
+        height = "90px"
+      ),
+      textAreaInput(
+        ns("message_fr"),
+        "Message (French)",
+        width = "100%",
+        height = "90px"
+      ),
+      div(
+        actionButton(ns("create_notification"), "Add notification"),
+        actionButton(ns("update_notification"), "Update selected"),
+        actionButton(ns("reset_form"), "Reset")
+      ),
+      verbatimTextOutput(ns("status"))
+    )
+  )
+}
+
+manageNotifications <- function(id, module_choices) {
+  moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+
+    if (!DBI::dbExistsTable(
+      session$userData$AquaCache,
+      DBI::Id(schema = "application", table = "notifications")
+    )) {
+      showModal(modalDialog(
+        title = "Missing table",
+        "The application.notifications table is not available.",
+        easyClose = TRUE,
+        footer = modalButton("Close")
+      ))
+      return()
+    }
+
+    check <- DBI::dbGetQuery(
+      session$userData$AquaCache,
+      "
+      SELECT
+        has_table_privilege(current_user, 'application.notifications', 'SELECT') AS can_select,
+        has_table_privilege(current_user, 'application.notifications', 'INSERT') AS can_insert,
+        has_table_privilege(current_user, 'application.notifications', 'UPDATE') AS can_update
+      "
+    )
+
+    if (!check$can_select) {
+      showModal(modalDialog(
+        title = "Insufficient Privileges",
+        "You do not have the necessary privileges to manage notifications.",
+        easyClose = TRUE,
+        footer = modalButton("Close")
+      ))
+      return()
+    }
+
+    if (!check$can_insert) {
+      shinyjs::disable("create_notification")
+    }
+    if (!check$can_update) {
+      shinyjs::disable("update_notification")
+    }
+
+    parse_text_array <- function(value) {
+      if (is.null(value) || !length(value) || all(is.na(value))) {
+        return(character())
+      }
+      if (is.list(value)) {
+        value <- value[[1]]
+      }
+      if (length(value) > 1) {
+        return(trimws(value))
+      }
+      value <- gsub("[{}\"]", "", value)
+      if (!nzchar(value)) {
+        return(character())
+      }
+      out <- trimws(unlist(strsplit(value, ",")))
+      out[nzchar(out)]
+    }
+
+    format_text_array <- function(values) {
+      if (is.null(values) || !length(values)) {
+        return(NULL)
+      }
+      values <- values[nzchar(values)]
+      if (!length(values)) {
+        return(NULL)
+      }
+      values <- gsub('"', '\\\"', values, fixed = TRUE)
+      paste0("{", paste(sprintf('"%s"', values), collapse = ","), "}")
+    }
+
+    parse_message <- function(value) {
+      parsed <- value
+      if (is.null(value) || all(is.na(value))) {
+        return(list(English = NA_character_, `Français` = NA_character_))
+      }
+      if (is.character(value)) {
+        parsed <- tryCatch(
+          jsonlite::fromJSON(value),
+          error = function(e) value
+        )
+      }
+      if (is.list(parsed)) {
+        english_msg <- parsed[["English"]]
+        french_msg <- parsed[["Français"]]
+        if (is.null(english_msg)) {
+          english_msg <- NA_character_
+        }
+        if (is.null(french_msg)) {
+          french_msg <- NA_character_
+        }
+        return(list(
+          English = english_msg,
+          `Français` = french_msg
+        ))
+      }
+      list(English = parsed, `Français` = NA_character_)
+    }
+
+    build_message_json <- function(en, fr) {
+      payload <- list()
+      if (nzchar(en)) {
+        payload[["English"]] <- en
+      }
+      if (nzchar(fr)) {
+        payload[["Français"]] <- fr
+      }
+      if (!length(payload)) {
+        return(NULL)
+      }
+      jsonlite::toJSON(payload, auto_unbox = TRUE)
+    }
+
+    load_notifications <- function() {
+      raw <- DBI::dbGetQuery(
+        session$userData$AquaCache,
+        "SELECT notification_id, active, target_module, message FROM application.notifications ORDER BY notification_id DESC"
+      )
+      if (!nrow(raw)) {
+        return(data.frame())
+      }
+      parsed <- lapply(raw$message, parse_message)
+      data.frame(
+        notification_id = raw$notification_id,
+        active = raw$active,
+        target_module = vapply(
+          raw$target_module,
+          function(target) paste(parse_text_array(target), collapse = ", "),
+          character(1)
+        ),
+        message_en = vapply(parsed, function(msg) msg$English, character(1)),
+        message_fr = vapply(parsed, function(msg) msg$`Français`, character(1)),
+        stringsAsFactors = FALSE
+      )
+    }
+
+    notifications <- reactiveVal(load_notifications())
+
+    refresh_notifications <- function() {
+      notifications(load_notifications())
+    }
+
+    status_msg <- reactiveVal("")
+    output$status <- renderText(status_msg())
+
+    reset_form <- function() {
+      updateCheckboxInput(session, "active", value = TRUE)
+      updateSelectizeInput(session, "target_module", selected = "all")
+      updateTextAreaInput(session, "message_en", value = "")
+      updateTextAreaInput(session, "message_fr", value = "")
+    }
+
+    output$notifications_table <- DT::renderDT({
+      DT::datatable(
+        notifications(),
+        rownames = FALSE,
+        selection = "single",
+        options = list(scrollX = TRUE)
+      )
+    })
+
+    observeEvent(input$notifications_table_rows_selected, {
+      selected <- input$notifications_table_rows_selected
+      if (!length(selected)) {
+        return()
+      }
+      row <- notifications()[selected, , drop = FALSE]
+      if (!nrow(row)) {
+        return()
+      }
+      updateCheckboxInput(session, "active", value = isTRUE(row$active))
+      updateSelectizeInput(
+        session,
+        "target_module",
+        selected = parse_text_array(row$target_module)
+      )
+      updateTextAreaInput(session, "message_en", value = row$message_en)
+      updateTextAreaInput(session, "message_fr", value = row$message_fr)
+    })
+
+    observeEvent(input$create_notification, {
+      targets <- input$target_module
+      message_json <- build_message_json(input$message_en, input$message_fr)
+
+      if (is.null(targets) || !length(targets)) {
+        status_msg("Please select at least one target module.")
+        return()
+      }
+      if (is.null(message_json)) {
+        status_msg("Please provide at least one message.")
+        return()
+      }
+
+      DBI::dbExecute(
+        session$userData$AquaCache,
+        "INSERT INTO application.notifications (active, target_module, message) VALUES ($1, ($2)::text[], $3)",
+        params = list(
+          isTRUE(input$active),
+          format_text_array(targets),
+          message_json
+        )
+      )
+
+      status_msg("Notification added.")
+      refresh_notifications()
+      reset_form()
+    })
+
+    observeEvent(input$update_notification, {
+      selected <- input$notifications_table_rows_selected
+      if (!length(selected)) {
+        status_msg("Select a notification to update.")
+        return()
+      }
+
+      targets <- input$target_module
+      message_json <- build_message_json(input$message_en, input$message_fr)
+
+      if (is.null(targets) || !length(targets)) {
+        status_msg("Please select at least one target module.")
+        return()
+      }
+      if (is.null(message_json)) {
+        status_msg("Please provide at least one message.")
+        return()
+      }
+
+      notification_id <- notifications()$notification_id[selected]
+      DBI::dbExecute(
+        session$userData$AquaCache,
+        "UPDATE application.notifications SET active = $1, target_module = ($2)::text[], message = $3 WHERE notification_id = $4",
+        params = list(
+          isTRUE(input$active),
+          format_text_array(targets),
+          message_json,
+          notification_id
+        )
+      )
+
+      status_msg("Notification updated.")
+      refresh_notifications()
+    })
+
+    observeEvent(input$reset_form, {
+      reset_form()
+      status_msg("")
+    })
+
+    observeEvent(input$target_module, {
+      if (!length(input$target_module)) {
+        return()
+      }
+      if (length(input$target_module) > 1 && "all" %in% input$target_module) {
+        updateSelectizeInput(session, "target_module", selected = "all")
+      }
+    })
+  })
+}

--- a/inst/apps/YGwater/server.R
+++ b/inst/apps/YGwater/server.R
@@ -200,6 +200,9 @@ app_server <- function(input, output, session) {
       if (!isTRUE(session$userData$can_create_role)) {
         nav_hide(id = "navbar", target = "manageUsers")
       }
+      if (!isTRUE(session$userData$admin_privs$manageNotifications)) {
+        nav_hide(id = "navbar", target = "manageNotifications")
+      }
       if (!isTRUE(session$userData$admin_privs$manageNewsContent)) {
         nav_hide(id = "navbar", target = "manageNewsContent")
       }
@@ -392,6 +395,7 @@ app_server <- function(input, output, session) {
 
     ui_loaded$changePwd <- FALSE
     ui_loaded$manageUsers <- FALSE
+    ui_loaded$manageNotifications <- FALSE
     ui_loaded$manageNewsContent <- FALSE
     ui_loaded$viewFeedback <- FALSE
 
@@ -400,6 +404,58 @@ app_server <- function(input, output, session) {
 
   ui_loaded <- reactiveValues()
   reset_ui_loaded() # Initialize the ui_loaded reactive values
+
+  notification_module_choices <- c(
+    "all",
+    "home",
+    "discPlot",
+    "contPlot",
+    "contPlotOld",
+    "mapLocs",
+    "mapParams",
+    "mapRaster",
+    "mapSnowbull",
+    "snowInfo",
+    "waterInfo",
+    "WQReport",
+    "snowBulletin",
+    "imgTableView",
+    "imgMapView",
+    "docTableView",
+    "discData",
+    "contData",
+    "wellRegistry",
+    "news",
+    "about",
+    "FOD",
+    "syncCont",
+    "syncDisc",
+    "addLocation",
+    "addSubLocation",
+    "addTimeseries",
+    "deploy_recover",
+    "calibrate",
+    "addContData",
+    "continuousCorrections",
+    "imputeMissing",
+    "editContData",
+    "grades_approvals_qualifiers",
+    "addDiscData",
+    "addSamples",
+    "addSampleSeries",
+    "editDiscData",
+    "addGuidelines",
+    "addDocs",
+    "addImgs",
+    "addImgSeries",
+    "simplerIndex",
+    "changePwd",
+    "manageUsers",
+    "manageNotifications",
+    "manageNewsContent",
+    "viewFeedback",
+    "visit"
+  )
 
   # Store the config info in the session. If the user connects with their own credentials these need to be used for plot rendering wrapped in an ExtendedTask or future/promises
   session$userData$config <- config
@@ -1368,6 +1424,15 @@ $(document).keyup(function(event) {
                 )
               )
             ),
+            manageNotifications = has_priv(
+              tbl = session$userData$table_privs,
+              "application.notifications",
+              list(c(
+                "INSERT",
+                "SELECT",
+                "UPDATE"
+              ))
+            ),
             viewFeedback = has_priv(
               tbl = session$userData$table_privs,
               "application.feedback",
@@ -1604,6 +1669,7 @@ $(document).keyup(function(event) {
           "addImgs",
           "addImgSeries",
           "manageNewsContent",
+          "manageNotifications",
           "viewFeedback",
           "visit",
           "changePwd",
@@ -2076,6 +2142,16 @@ $(document).keyup(function(event) {
         ))
         ui_loaded$manageNewsContent <- TRUE
         manageNewsContent("manageNewsContent")
+      }
+    }
+    if (input$navbar == "manageNotifications") {
+      if (!ui_loaded$manageNotifications) {
+        output$manageNotifications_ui <- renderUI(manageNotificationsUI(
+          "manageNotifications",
+          notification_module_choices
+        ))
+        ui_loaded$manageNotifications <- TRUE
+        manageNotifications("manageNotifications", notification_module_choices)
       }
     }
     if (input$navbar == "viewFeedback") {

--- a/inst/apps/YGwater/ui.R
+++ b/inst/apps/YGwater/ui.R
@@ -479,6 +479,11 @@ app_ui <- function(request) {
               uiOutput("manageUsers_ui")
             ),
             nav_panel(
+              title = "Manage notifications",
+              value = "manageNotifications",
+              uiOutput("manageNotifications_ui")
+            ),
+            nav_panel(
               title = "Update news page content",
               value = "manageNewsContent",
               uiOutput("manageNewsContent_ui")


### PR DESCRIPTION
### Motivation
- Provide admins a UI to create, edit and control in-app notifications stored in the `application.notifications` table so messages can be targeted to specific modules or to `all` modules.
- Allow localized (English/French) notification messages and let modules display active notices by server-name as implemented in existing modules via `application_notifications_ui`.

### Description
- Added a new admin module `manageNotifications` with UI and server logic in `inst/apps/YGwater/modules/admin/applicationTasks/manageNotifications.R` to list, create and update notifications (supports `active`, `target_module` array and JSON `message`).
- Registered the new module in globals by sourcing it from `YGwater_globals.R` and added the admin nav panel entry in `ui.R` under the same Admin nav_menu as users/feedback/news.
- Wired server-side loading, permission checks and lazy UI rendering in `server.R`, including a `notification_module_choices` vector of server names passed to the module and an admin privilege flag `manageNotifications` derived from `session$userData$table_privs`.
- Improved robustness of message parsing to handle missing language keys when reading stored JSON messages.

### Testing
- No automated tests were executed as requested in the project instructions; the change was implemented and integrated but not run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696ea6c75814832fadbfe244be4feb4d)