### PR TITLE
Add notification banners to modules and pass language through module servers

### DIFF
--- a/inst/apps/YGwater/modules/admin/applicationTasks/adminLanding.R
+++ b/inst/apps/YGwater/modules/admin/applicationTasks/adminLanding.R
@@ -1,6 +1,7 @@
 adminLandingUI <- function(id) {
   ns <- NS(id)
   page_fluid(
+    uiOutput(ns("banner")),
     tags$div(
       tags$h2("Admin overview"),
       tags$p(
@@ -52,6 +53,18 @@ adminLandingUI <- function(id) {
   )
 }
 
-adminLanding <- function(id) {
-  moduleServer(id, function(input, output, session) {})
+adminLanding <- function(id, language) {
+  moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "adminHome"
+      )
+    })
+  })
 }

--- a/inst/apps/YGwater/modules/admin/applicationTasks/manageNewsContent.R
+++ b/inst/apps/YGwater/modules/admin/applicationTasks/manageNewsContent.R
@@ -1,6 +1,7 @@
 manageNewsContentUI <- function(id) {
   ns <- NS(id)
   page_fluid(
+    uiOutput(ns("banner")),
     tabsetPanel(
       id = ns("tabs"),
       tabPanel(
@@ -77,9 +78,19 @@ manageNewsContentUI <- function(id) {
   )
 }
 
-manageNewsContent <- function(id) {
+manageNewsContent <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "manageNewsContent"
+      )
+    })
 
     text_df <- reactiveVal(data.frame())
     image_df <- reactiveVal(data.frame())

--- a/inst/apps/YGwater/modules/admin/applicationTasks/manageNotifications.R
+++ b/inst/apps/YGwater/modules/admin/applicationTasks/manageNotifications.R
@@ -2,6 +2,7 @@ manageNotificationsUI <- function(id, module_choices) {
   ns <- NS(id)
   page_fluid(
     tagList(
+      uiOutput(ns("banner")),
       tags$p(
         "Notifications appear in modules by server name. Use 'all' to show a",
         "notification across the entire application."
@@ -39,9 +40,19 @@ manageNotificationsUI <- function(id, module_choices) {
   )
 }
 
-manageNotifications <- function(id, module_choices) {
+manageNotifications <- function(id, module_choices, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "manageNotifications"
+      )
+    })
 
     if (
       !DBI::dbExistsTable(

--- a/inst/apps/YGwater/modules/admin/applicationTasks/viewFeedback.R
+++ b/inst/apps/YGwater/modules/admin/applicationTasks/viewFeedback.R
@@ -1,13 +1,24 @@
 viewFeedbackUI <- function(id) {
   ns <- NS(id)
   page_fluid(
+    uiOutput(ns("banner")),
     DT::DTOutput(ns("feedback_table"))
   )
 }
 
-viewFeedback <- function(id) {
+viewFeedback <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "viewFeedback"
+      )
+    })
 
     check <- DBI::dbGetQuery(
       session$userData$AquaCache,

--- a/inst/apps/YGwater/modules/admin/boreholes_wells/simplerIndex.R
+++ b/inst/apps/YGwater/modules/admin/boreholes_wells/simplerIndex.R
@@ -1025,17 +1025,28 @@ simplerIndexUI <- function(id) {
             'estimated_yield',
             'notes_well',
             'share_with_well'
-          ))
-        ),
+      ))
+    ),
+    uiOutput(ns("banner")),
         collapse = ','
       )
     )))
   )
 } # End of UI function
 
-simplerIndex <- function(id) {
+simplerIndex <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "simplerIndex"
+      )
+    })
 
     # Load the helper functions
     # local = TRUE ensures the functions are loaded into this module's environment only

--- a/inst/apps/YGwater/modules/admin/continuousData/addContData.R
+++ b/inst/apps/YGwater/modules/admin/continuousData/addContData.R
@@ -35,6 +35,7 @@ addContDataUI <- function(id) {
     ),
 
     page_fluid(
+      uiOutput(ns("banner")),
       actionButton(
         ns("reload_module"),
         "Reload module data",
@@ -125,9 +126,19 @@ addContDataUI <- function(id) {
   )
 }
 
-addContData <- function(id) {
+addContData <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "addContData"
+      )
+    })
 
     outputs <- reactiveValues() # Used to pass the user on to adding a timeseries directly
 

--- a/inst/apps/YGwater/modules/admin/continuousData/addTimeseries.R
+++ b/inst/apps/YGwater/modules/admin/continuousData/addTimeseries.R
@@ -5,14 +5,25 @@ addTimeseriesUI <- function(id) {
 
   tagList(
     page_fluid(
+      uiOutput(ns("banner")),
       uiOutput(ns("ui"))
     )
   )
 }
 
-addTimeseries <- function(id) {
+addTimeseries <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "addTimeseries"
+      )
+    })
 
     moduleData <- reactiveValues()
 

--- a/inst/apps/YGwater/modules/admin/continuousData/continuousCorrections.R
+++ b/inst/apps/YGwater/modules/admin/continuousData/continuousCorrections.R
@@ -49,6 +49,7 @@ continuousCorrectionsUI <- function(id) {
     ),
 
     page_fluid(
+      uiOutput(ns("banner")),
       accordion(
         id = ns("accordion1"),
         open = "ts_selection_panel",
@@ -109,9 +110,19 @@ continuousCorrectionsUI <- function(id) {
   )
 }
 
-continuousCorrections <- function(id) {
+continuousCorrections <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "continuousCorrections"
+      )
+    })
 
     check <- DBI::dbGetQuery(
       session$userData$AquaCache,

--- a/inst/apps/YGwater/modules/admin/continuousData/editContData.R
+++ b/inst/apps/YGwater/modules/admin/continuousData/editContData.R
@@ -3,13 +3,24 @@
 editContDataUI <- function(id) {
   ns <- NS(id)
   page_fluid(
+    uiOutput(ns("banner")),
     textOutput(ns("placeholder"))
   )
 }
 
-editContData <- function(id) {
+editContData <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "editContData"
+      )
+    })
 
     output$placeholder <- renderText(
       "Placeholder for continuous data modify/delete module"

--- a/inst/apps/YGwater/modules/admin/continuousData/grades_approvals_qualifiers.R
+++ b/inst/apps/YGwater/modules/admin/continuousData/grades_approvals_qualifiers.R
@@ -19,6 +19,7 @@ grades_approvals_qualifiersUI <- function(id) {
       ))
     ),
     page_fluid(
+      uiOutput(ns("banner")),
       accordion(
         id = ns("accordion_ts"),
         open = "ts_panel",
@@ -139,9 +140,19 @@ grades_approvals_qualifiersUI <- function(id) {
   )
 }
 
-grades_approvals_qualifiers <- function(id) {
+grades_approvals_qualifiers <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "grades_approvals_qualifiers"
+      )
+    })
 
     parse_datetime <- function(value) {
       if (is.null(value) || !nzchar(value)) {

--- a/inst/apps/YGwater/modules/admin/continuousData/imputeMissing.R
+++ b/inst/apps/YGwater/modules/admin/continuousData/imputeMissing.R
@@ -49,6 +49,7 @@ imputeMissingUI <- function(id) {
     ),
 
     page_fluid(
+      uiOutput(ns("banner")),
       accordion(
         id = ns("accordion1"),
         open = "ts_panel",
@@ -122,9 +123,19 @@ imputeMissingUI <- function(id) {
 }
 
 
-imputeMissing <- function(id) {
+imputeMissing <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "imputeMissing"
+      )
+    })
 
     ts_meta <- reactive({
       dbGetQueryDT(

--- a/inst/apps/YGwater/modules/admin/continuousData/syncCont.R
+++ b/inst/apps/YGwater/modules/admin/continuousData/syncCont.R
@@ -1,6 +1,7 @@
 syncContUI <- function(id) {
   ns <- NS(id)
   page_fluid(
+    uiOutput(ns("banner")),
     h3("Synchronize continuous timeseries"),
     tooltip(
       checkboxInput(ns("all_ts"), "All timeseries", FALSE),
@@ -30,9 +31,19 @@ syncContUI <- function(id) {
   )
 }
 
-syncCont <- function(id) {
+syncCont <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "syncCont"
+      )
+    })
 
     check <- DBI::dbGetQuery(
       session$userData$AquaCache,

--- a/inst/apps/YGwater/modules/admin/discreteData/addDiscData.R
+++ b/inst/apps/YGwater/modules/admin/discreteData/addDiscData.R
@@ -34,6 +34,7 @@ addDiscDataUI <- function(id) {
     ),
 
     page_fluid(
+      uiOutput(ns("banner")),
       accordion(
         id = ns("accordion1"),
         open = "loc_panel",
@@ -129,9 +130,19 @@ addDiscDataUI <- function(id) {
   )
 }
 
-addDiscData <- function(id) {
+addDiscData <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "addDiscData"
+      )
+    })
 
     outputs <- reactiveValues()
 

--- a/inst/apps/YGwater/modules/admin/discreteData/addGuidelines.R
+++ b/inst/apps/YGwater/modules/admin/discreteData/addGuidelines.R
@@ -73,6 +73,7 @@ Shiny.addCustomMessageHandler('insertAtCursor', function(msg) {
       ))
     ),
 
+    uiOutput(ns("banner")),
     page_sidebar(
       sidebar = sidebar(
         title = NULL,
@@ -244,9 +245,19 @@ Shiny.addCustomMessageHandler('insertAtCursor', function(msg) {
   )
 }
 
-addGuidelines <- function(id) {
+addGuidelines <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "addGuidelines"
+      )
+    })
 
     moduleData <- reactiveValues(
       guidelines = DBI::dbGetQuery(

--- a/inst/apps/YGwater/modules/admin/discreteData/addSampleSeries.R
+++ b/inst/apps/YGwater/modules/admin/discreteData/addSampleSeries.R
@@ -5,14 +5,25 @@ addSampleSeriesUI <- function(id) {
 
   tagList(
     page_fluid(
+      uiOutput(ns("banner")),
       uiOutput(ns("ui"))
     )
   )
 }
 
-addSampleSeries <- function(id) {
+addSampleSeries <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "addSampleSeries"
+      )
+    })
 
     moduleData <- reactiveValues()
     selected_series <- reactiveVal(NULL)

--- a/inst/apps/YGwater/modules/admin/discreteData/addSamples.R
+++ b/inst/apps/YGwater/modules/admin/discreteData/addSamples.R
@@ -35,14 +35,25 @@ addSamplesUI <- function(id) {
       ))
     ),
     page_fluid(
+      uiOutput(ns("banner")),
       uiOutput(ns("ui"))
     )
   )
 }
 
-addSamples <- function(id) {
+addSamples <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "addSamples"
+      )
+    })
 
     moduleData <- reactiveValues()
     selected_sample_ids <- reactiveVal(integer())

--- a/inst/apps/YGwater/modules/admin/discreteData/editDiscData.R
+++ b/inst/apps/YGwater/modules/admin/discreteData/editDiscData.R
@@ -3,13 +3,24 @@
 editDiscDataUI <- function(id) {
   ns <- NS(id)
   page_fluid(
+    uiOutput(ns("banner")),
     textOutput(ns("placeholder"))
   )
 }
 
-editDiscData <- function(id) {
+editDiscData <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "editDiscData"
+      )
+    })
 
     output$placeholder <- renderText(
       "Placeholder for discrete data modify/delete module"

--- a/inst/apps/YGwater/modules/admin/discreteData/syncDisc.R
+++ b/inst/apps/YGwater/modules/admin/discreteData/syncDisc.R
@@ -1,6 +1,7 @@
 syncDiscUI <- function(id) {
   ns <- NS(id)
   page_fluid(
+    uiOutput(ns("banner")),
     h3("Synchronize sample series"),
     tooltip(
       checkboxInput(ns("all_ss"), "All sample series", FALSE),
@@ -32,9 +33,19 @@ syncDiscUI <- function(id) {
   )
 }
 
-syncDisc <- function(id) {
+syncDisc <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "syncDisc"
+      )
+    })
 
     check <- DBI::dbGetQuery(
       session$userData$AquaCache,

--- a/inst/apps/YGwater/modules/admin/documents/addDocs.R
+++ b/inst/apps/YGwater/modules/admin/documents/addDocs.R
@@ -3,13 +3,24 @@
 addDocsUI <- function(id) {
   ns <- NS(id)
   page_fluid(
+    uiOutput(ns("banner")),
     textOutput(ns("placeholder"))
   )
 }
 
-addDocs <- function(id) {
+addDocs <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "addDocs"
+      )
+    })
 
     output$placeholder <- renderText("Placeholder for documents main module")
   }) # End of moduleServer

--- a/inst/apps/YGwater/modules/admin/equipment/calibrate.R
+++ b/inst/apps/YGwater/modules/admin/equipment/calibrate.R
@@ -67,6 +67,7 @@ calibrateUI <- function(id) {
         text = instrSelectBGCol,
         functions = c("backgroundCol")
       ),
+      uiOutput(ns("banner")),
       # Tabs
       tabsetPanel(
         id = ns("tab_panel"),
@@ -598,9 +599,19 @@ calibrateUI <- function(id) {
   ) # End of tagList
 }
 
-calibrate <- function(id) {
+calibrate <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "calibrate"
+      )
+    })
 
     # Custom alert function using Shiny's showNotification (replaces old shinyAlert dependencies)
     alert <- function(title, text = NULL, type = NULL, timer = 2000) {

--- a/inst/apps/YGwater/modules/admin/field/deploy_recover.R
+++ b/inst/apps/YGwater/modules/admin/field/deploy_recover.R
@@ -3,13 +3,24 @@
 deploy_recover_UI <- function(id) {
   ns <- NS(id)
   page_fluid(
+    uiOutput(ns("banner")),
     textOutput(ns("placeholder"))
   )
 }
 
-deploy_recover <- function(id) {
+deploy_recover <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "deploy_recover"
+      )
+    })
 
     output$placeholder <- renderText(
       "Placeholder for equipment deloyment/recovery"

--- a/inst/apps/YGwater/modules/admin/field/field_visit.R
+++ b/inst/apps/YGwater/modules/admin/field/field_visit.R
@@ -16,6 +16,7 @@
 visitUI <- function(id) {
   ns <- NS(id)
   page_fluid(
+    uiOutput(ns("banner")),
     title = "Field Visits",
     p(
       "Field visit module is under development. Anything you see here may not work as expected."
@@ -24,9 +25,19 @@ visitUI <- function(id) {
   ) # End of page_fluid
 }
 
-visit <- function(id) {
+visit <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "visit"
+      )
+    })
 
     moduleData <- reactiveValues()
     visitData <- reactiveValues(

--- a/inst/apps/YGwater/modules/admin/imgupload/addImgSeries.R
+++ b/inst/apps/YGwater/modules/admin/imgupload/addImgSeries.R
@@ -5,14 +5,25 @@ addImgSeriesUI <- function(id) {
 
   tagList(
     page_fluid(
+      uiOutput(ns("banner")),
       uiOutput(ns("ui"))
     )
   )
 }
 
-addImgSeries <- function(id) {
+addImgSeries <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "addImgSeries"
+      )
+    })
 
     moduleData <- reactiveValues()
 

--- a/inst/apps/YGwater/modules/admin/imgupload/addImgs.R
+++ b/inst/apps/YGwater/modules/admin/imgupload/addImgs.R
@@ -11,6 +11,7 @@ addImgsUI <- function(id) {
   ns <- NS(id)
 
   page_fluid(
+    uiOutput(ns("banner")),
     br(),
     fluidRow(
       column(
@@ -227,9 +228,19 @@ addImgsUI <- function(id) {
 
 
 # Define the server logic
-addImgs <- function(id) {
+addImgs <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "addImgs"
+      )
+    })
 
     # Define custom functions  #######
     # Render the data table

--- a/inst/apps/YGwater/modules/admin/locations/addLocation.R
+++ b/inst/apps/YGwater/modules/admin/locations/addLocation.R
@@ -35,15 +35,26 @@ addLocationUI <- function(id) {
       ))
     ),
     page_fluid(
+      uiOutput(ns("banner")),
       uiOutput(ns("ui"))
     )
   )
 }
 
 
-addLocation <- function(id, inputs) {
+addLocation <- function(id, inputs, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "addLocation"
+      )
+    })
 
     # Assign the input value to a reactive right away (passed in from the main server) as it's reset to NULL as soon as this module is loaded
     moduleInputs <- reactiveValues(

--- a/inst/apps/YGwater/modules/admin/locations/addSubLocation.R
+++ b/inst/apps/YGwater/modules/admin/locations/addSubLocation.R
@@ -5,15 +5,26 @@ addSubLocationUI <- function(id) {
 
   tagList(
     page_fluid(
+      uiOutput(ns("banner")),
       uiOutput(ns("ui"))
     )
   )
 }
 
 
-addSubLocation <- function(id, inputs) {
+addSubLocation <- function(id, inputs, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "addSubLocation"
+      )
+    })
 
     # Assign the input value to a reactive right away (passed in from the main server) as it's reset to NULL as soon as this module is loaded
     moduleInputs <- reactiveValues(

--- a/inst/apps/YGwater/modules/admin/locations/locationMetadata.R
+++ b/inst/apps/YGwater/modules/admin/locations/locationMetadata.R
@@ -3,13 +3,24 @@
 locsMetaUI <- function(id) {
   ns <- NS(id)
   page_fluid(
+    uiOutput(ns("banner")),
     textOutput(ns("placeholder"))
   )
 }
 
-locsMetaServer <- function(id, data) {
+locsMetaServer <- function(id, data, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "locsMeta"
+      )
+    })
 
     output$placeholder <- renderText(
       "Placeholder for location metadata view/edit module"

--- a/inst/apps/YGwater/modules/admin/users/changePassword.R
+++ b/inst/apps/YGwater/modules/admin/users/changePassword.R
@@ -1,6 +1,7 @@
 changePasswordUI <- function(id) {
   ns <- NS(id)
   page_fluid(
+    uiOutput(ns("banner")),
     uiOutput(ns("pwd_ui"))
   )
 }
@@ -9,6 +10,16 @@ changePassword <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     trl <- function(key) tr(key, language$language) # tiny helper
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "changePwd"
+      )
+    })
 
     output$pwd_ui <- renderUI({
       req(language$language)

--- a/inst/apps/YGwater/modules/admin/users/manageUsers.R
+++ b/inst/apps/YGwater/modules/admin/users/manageUsers.R
@@ -2,6 +2,7 @@ manageUsersUI <- function(id) {
   ns <- NS(id)
   page_fluid(
     tagList(
+      uiOutput(ns("banner")),
       selectizeInput(
         ns("group_user"),
         NULL,
@@ -41,9 +42,19 @@ manageUsersUI <- function(id) {
   )
 }
 
-manageUsers <- function(id) {
+manageUsers <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "manageUsers"
+      )
+    })
 
     # Fetch the schema names; this is used to grant usage to groups on relevant schemas
     schemas <- DBI::dbGetQuery(

--- a/inst/apps/YGwater/modules/client/FOD/FOD_main.R
+++ b/inst/apps/YGwater/modules/client/FOD/FOD_main.R
@@ -3,6 +3,7 @@
 FODUI <- function(id) {
   ns <- NS(id)
   page_fluid(
+    uiOutput(ns("banner")),
     sidebarPanel(
       selectInput(ns("comment_type"), "Select comment type", choices = c("General comments", "Location-specific comments"), selected = "General comments"),
       selectInput(ns("comment_data_type"), "Select a data type", choices = c("All", "Water levels", "Water flows", "Bridge freeboard", "Snow pillows", "Precipitation")),
@@ -17,12 +18,20 @@ FODUI <- function(id) {
   )
 }
 
-FOD <- function(id) {
-  
+FOD <- function(id, language) {
   moduleServer(id, function(input, output, session) {
-    
     ns <- session$ns  # Used for generating UI elements from server
-    
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "FOD"
+      )
+    })
+
     #Create containers
     FOD_comments <- reactiveValues(comments = list(),
                                    dates = vector(),

--- a/inst/apps/YGwater/modules/client/data/continuousData.R
+++ b/inst/apps/YGwater/modules/client/data/continuousData.R
@@ -33,6 +33,7 @@ contDataUI <- function(id) {
         ns("accordion")
       ))
     ),
+    uiOutput(ns("banner")),
     uiOutput(ns("top")),
     page_sidebar(
       sidebar = sidebar(
@@ -50,6 +51,16 @@ contDataUI <- function(id) {
 contData <- function(id, language, inputs) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns # Used to create UI elements within the server code
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "contData"
+      )
+    })
 
     # Functions and data fetch ################
     # Adjust multiple selection based on if 'all' is selected

--- a/inst/apps/YGwater/modules/client/documents/document_table_view.R
+++ b/inst/apps/YGwater/modules/client/documents/document_table_view.R
@@ -3,6 +3,7 @@
 docTableViewUI <- function(id) {
   ns <- NS(id)
   tagList(
+    uiOutput(ns("banner")),
     tags$style(HTML(sprintf(
       "
       /* Force DT table background to white (scoped to this module/table) */
@@ -35,6 +36,16 @@ docTableViewUI <- function(id) {
 docTableView <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "docTableView"
+      )
+    })
 
     moduleData <- reactiveValues(
       docs = dbGetQueryDT(

--- a/inst/apps/YGwater/modules/client/plot/continuousPlot_old.R
+++ b/inst/apps/YGwater/modules/client/plot/continuousPlot_old.R
@@ -19,6 +19,7 @@ contPlotOldUI <- function(id) {
       ))
     ),
 
+    uiOutput(ns("banner")),
     page_sidebar(
       sidebar = sidebar(
         title = NULL,
@@ -35,6 +36,16 @@ contPlotOldUI <- function(id) {
 contPlotOld <- function(id, language, windowDims, inputs) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns # Used to create UI elements within server
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "contPlotOld"
+      )
+    })
 
     # Adjust multiple selection based on if 'all' is selected
     observeFilterInput <- function(inputId) {

--- a/inst/apps/YGwater/modules/client/reports/WQReport.R
+++ b/inst/apps/YGwater/modules/client/reports/WQReport.R
@@ -1,6 +1,7 @@
 WQReportUI <- function(id) {
   ns <- NS(id)
   tagList(
+    uiOutput(ns("banner")),
     # Custom CSS below is for consistency with the look elsewhere in the app.
     tags$head(tags$link(
       rel = "stylesheet",
@@ -225,6 +226,16 @@ WQReportUI <- function(id) {
 WQReport <- function(id, mdb_files, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns # Used to create UI elements in the server code
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "WQReport"
+      )
+    })
 
     EQWin_selector <- reactiveVal(FALSE)
     observeEvent(input$data_source, {

--- a/inst/apps/YGwater/modules/client/reports/snowBulletin.R
+++ b/inst/apps/YGwater/modules/client/reports/snowBulletin.R
@@ -1,6 +1,7 @@
 snowBulletinUIMod <- function(id) {
   ns <- NS(id)
   tagList(
+    uiOutput(ns("banner")),
     # Custom CSS below is for consistency with the sidebarPanel look elsewhere in the app.
     tags$head(tags$link(
       rel = "stylesheet",
@@ -19,6 +20,16 @@ snowBulletinUIMod <- function(id) {
 snowBulletinMod <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns # Used to create UI elements in the server code
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "snowBulletin"
+      )
+    })
 
     # Create reactiveValues to store the user's selections. Used if switching between languages.
     selections <- reactiveValues(

--- a/inst/apps/YGwater/modules/client/reports/snowInfo.R
+++ b/inst/apps/YGwater/modules/client/reports/snowInfo.R
@@ -1,6 +1,7 @@
 snowInfoUIMod <- function(id) {
   ns <- NS(id)
   tagList(
+    uiOutput(ns("banner")),
     # Custom CSS below is for consistency with the sidebarPanel look elsewhere in the app.
     tags$head(tags$link(
       rel = "stylesheet",
@@ -19,6 +20,16 @@ snowInfoUIMod <- function(id) {
 snowInfoMod <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns # Used to create UI elements in the server code
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "snowInfo"
+      )
+    })
 
     moduleData <- reactiveValues(
       locs = dbGetQueryDT(

--- a/inst/apps/YGwater/modules/client/reports/waterInfo.R
+++ b/inst/apps/YGwater/modules/client/reports/waterInfo.R
@@ -1,6 +1,7 @@
 waterInfoUIMod <- function(id) {
   ns <- NS(id)
   tagList(
+    uiOutput(ns("banner")),
     # Custom CSS below is for consistency with the look elsewhere in the app.
     tags$head(tags$link(
       rel = "stylesheet",
@@ -19,6 +20,16 @@ waterInfoUIMod <- function(id) {
 waterInfoMod <- function(id, language) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns # Used to create UI elements in the server code
+
+    output$banner <- renderUI({
+      req(language$language)
+      application_notifications_ui(
+        ns = ns,
+        lang = language$language,
+        con = session$userData$AquaCache,
+        module_id = "waterInfo"
+      )
+    })
 
     moduleData <- reactiveValues(
       locs = dbGetQueryDT(

--- a/inst/apps/YGwater/server.R
+++ b/inst/apps/YGwater/server.R
@@ -451,6 +451,7 @@ app_server <- function(input, output, session) {
     "addImgs",
     "addImgSeries",
     "simplerIndex",
+    "adminHome",
     "changePwd",
     "manageUsers",
     "manageNotifications",
@@ -1749,8 +1750,8 @@ $(document).keyup(function(event) {
         ui_loaded$contPlotOld <- TRUE
         contPlotOld(
           "contPlotOld",
-          windowDims,
           language = languageSelection,
+          windowDims = windowDims,
           inputs = moduleOutputs$mapLocs
         )
         if (!is.null(moduleOutputs$mapLocs)) {
@@ -1822,7 +1823,7 @@ $(document).keyup(function(event) {
         output$fod_ui <- renderUI(FODUI("FOD"))
         ui_loaded$FOD <- TRUE
         # Call the server
-        FOD("FOD")
+        FOD("FOD", language = languageSelection)
       }
     }
     ### Image nav_menu ##########################
@@ -1954,21 +1955,25 @@ $(document).keyup(function(event) {
       if (!ui_loaded$syncCont) {
         output$syncCont_ui <- renderUI(syncContUI("syncCont"))
         ui_loaded$syncCont <- TRUE
-        syncCont("syncCont") # Call the server
+        syncCont("syncCont", language = languageSelection) # Call the server
       }
     }
     if (input$navbar == "syncDisc") {
       if (!ui_loaded$syncDisc) {
         output$syncDisc_ui <- renderUI(syncDiscUI("syncDisc"))
         ui_loaded$syncDisc <- TRUE
-        syncDisc("syncDisc") # Call the server
+        syncDisc("syncDisc", language = languageSelection) # Call the server
       }
     }
     if (input$navbar == "addLocation") {
       if (!ui_loaded$addLocation) {
         output$addLocation_ui <- renderUI(addLocationUI("addLocation"))
         ui_loaded$addLocation <- TRUE
-        addLocation("addLocation", inputs = moduleOutputs$addDiscData) # Call the server
+        addLocation(
+          "addLocation",
+          inputs = moduleOutputs$addDiscData,
+          language = languageSelection
+        ) # Call the server
         if (!is.null(moduleOutputs$addDiscData)) {
           moduleOutputs$addDiscData$location <- NULL
           moduleOutputs$addDiscData$change_tab <- NULL
@@ -1979,7 +1984,11 @@ $(document).keyup(function(event) {
       if (!ui_loaded$addSubLocation) {
         output$addSubLocation_ui <- renderUI(addSubLocationUI("addSubLocation"))
         ui_loaded$addSubLocation <- TRUE
-        addSubLocation("addSubLocation", inputs = moduleOutputs$addDiscData) # Call the server
+        addSubLocation(
+          "addSubLocation",
+          inputs = moduleOutputs$addDiscData,
+          language = languageSelection
+        ) # Call the server
         if (!is.null(moduleOutputs$addDiscData)) {
           moduleOutputs$addDiscData$sublocation <- NULL
           moduleOutputs$addDiscData$change_tab <- NULL
@@ -1990,7 +1999,7 @@ $(document).keyup(function(event) {
       if (!ui_loaded$addTimeseries) {
         output$addTimeseries_ui <- renderUI(addTimeseriesUI("addTimeseries"))
         ui_loaded$addTimeseries <- TRUE
-        addTimeseries("addTimeseries") # Call the server
+        addTimeseries("addTimeseries", language = languageSelection) # Call the server
         if (!is.null(moduleOutputs$addContData)) {
           moduleOutputs$addContData$change_tab <- NULL
         }
@@ -2002,21 +2011,24 @@ $(document).keyup(function(event) {
           "deploy_recover"
         )) # Render the UI
         ui_loaded$deploy_recover <- TRUE
-        deploy_recover("deploy_recover") # Call the server
+        deploy_recover("deploy_recover", language = languageSelection) # Call the server
       }
     }
     if (input$navbar == "calibrate") {
       if (!ui_loaded$calibrate) {
         output$calibrate_ui <- renderUI(calibrateUI("calibrate")) # Render the UI
         ui_loaded$calibrate <- TRUE
-        calibrate("calibrate") # Call the server
+        calibrate("calibrate", language = languageSelection) # Call the server
       }
     }
     if (input$navbar == "addContData") {
       if (!ui_loaded$addContData) {
         output$addContData_ui <- renderUI(addContDataUI("addContData")) # Render the UI
         ui_loaded$addContData <- TRUE
-        moduleOutputs$addContData <- addContData("addContData") # Call the server
+        moduleOutputs$addContData <- addContData(
+          "addContData",
+          language = languageSelection
+        ) # Call the server
       }
       # Observe the change_tab output from the addContData module
       observe({
@@ -2036,21 +2048,21 @@ $(document).keyup(function(event) {
           "continuousCorrections"
         ))
         ui_loaded$continuousCorrections <- TRUE
-        continuousCorrections("continuousCorrections")
+        continuousCorrections("continuousCorrections", language = languageSelection)
       }
     }
     if (input$navbar == "imputeMissing") {
       if (!ui_loaded$imputeMissing) {
         output$imputeMissing_ui <- renderUI(imputeMissingUI("imputeMissing")) # Render the UI
         ui_loaded$imputeMissing <- TRUE
-        imputeMissing("imputeMissing") # Call the server
+        imputeMissing("imputeMissing", language = languageSelection) # Call the server
       }
     }
     if (input$navbar == "editContData") {
       if (!ui_loaded$editContData) {
         output$editContData_ui <- renderUI(editContDataUI("editContData")) # Render the UI
         ui_loaded$editContData <- TRUE
-        editContData("editContData") # Call the server
+        editContData("editContData", language = languageSelection) # Call the server
       }
     }
     if (input$navbar == "grades_approvals_qualifiers") {
@@ -2059,14 +2071,20 @@ $(document).keyup(function(event) {
           "grades_approvals_qualifiers"
         )) # Render the UI
         ui_loaded$grades_approvals_qualifiers <- TRUE
-        grades_approvals_qualifiers("grades_approvals_qualifiers") # Call the server
+        grades_approvals_qualifiers(
+          "grades_approvals_qualifiers",
+          language = languageSelection
+        ) # Call the server
       }
     }
     if (input$navbar == "addDiscData") {
       if (!ui_loaded$addDiscData) {
         output$addDiscData_ui <- renderUI(addDiscDataUI("addDiscData")) # Render the UI
         ui_loaded$addDiscData <- TRUE
-        moduleOutputs$addDiscData <- addDiscData("addDiscData") # Call the server
+        moduleOutputs$addDiscData <- addDiscData(
+          "addDiscData",
+          language = languageSelection
+        ) # Call the server
       }
       # Observe the change_tab output from the addDiscData module
       observe({
@@ -2084,21 +2102,21 @@ $(document).keyup(function(event) {
       if (!ui_loaded$addSamples) {
         output$addSamples_ui <- renderUI(addSamplesUI("addSamples"))
         ui_loaded$addSamples <- TRUE
-        addSamples("addSamples")
+        addSamples("addSamples", language = languageSelection)
       }
     }
     if (input$navbar == "editDiscData") {
       if (!ui_loaded$editDiscData) {
         output$editDiscData_ui <- renderUI(editDiscDataUI("editDiscData")) # Render the UI
         ui_loaded$editDiscData <- TRUE
-        editDiscData("editDiscData") # Call the server
+        editDiscData("editDiscData", language = languageSelection) # Call the server
       }
     }
     if (input$navbar == "addGuidelines") {
       if (!ui_loaded$addGuidelines) {
         output$addGuidelines_ui <- renderUI(addGuidelinesUI("addGuidelines")) # Render the UI
         ui_loaded$addGuidelines <- TRUE
-        addGuidelines("addGuidelines") # Call the server
+        addGuidelines("addGuidelines", language = languageSelection) # Call the server
       }
     }
     if (input$navbar == "addSampleSeries") {
@@ -2107,35 +2125,35 @@ $(document).keyup(function(event) {
           "addSampleSeries"
         ))
         ui_loaded$addSampleSeries <- TRUE
-        addSampleSeries("addSampleSeries")
+        addSampleSeries("addSampleSeries", language = languageSelection)
       }
     }
     if (input$navbar == "addDocs") {
       if (!ui_loaded$addDocs) {
         output$addDocs_ui <- renderUI(addDocsUI("addDocs")) # Render the UI
         ui_loaded$addDocs <- TRUE
-        addDocs("addDocs") # Call the server
+        addDocs("addDocs", language = languageSelection) # Call the server
       }
     }
     if (input$navbar == "addImgs") {
       if (!ui_loaded$addImgs) {
         output$addImgs_ui <- renderUI(addImgsUI("addImgs")) # Render the UI
         ui_loaded$addImgs <- TRUE
-        addImgs("addImgs") # Call the server
+        addImgs("addImgs", language = languageSelection) # Call the server
       }
     }
     if (input$navbar == "addImgSeries") {
       if (!ui_loaded$addImgSeries) {
         output$addImgSeries_ui <- renderUI(addImgSeriesUI("addImgSeries")) # Render the UI
         ui_loaded$addImgSeries <- TRUE
-        addImgSeries("addImgSeries") # Call the server
+        addImgSeries("addImgSeries", language = languageSelection) # Call the server
       }
     }
     if (input$navbar == "simplerIndex") {
       if (!ui_loaded$simplerIndex) {
         output$simplerIndex_ui <- renderUI(simplerIndexUI("simplerIndex")) # Render the UI
         ui_loaded$simplerIndex <- TRUE
-        simplerIndex("simplerIndex") # Call the server
+        simplerIndex("simplerIndex", language = languageSelection) # Call the server
       }
     }
     if (input$navbar == "manageNewsContent") {
@@ -2144,14 +2162,14 @@ $(document).keyup(function(event) {
           "manageNewsContent"
         ))
         ui_loaded$manageNewsContent <- TRUE
-        manageNewsContent("manageNewsContent")
+        manageNewsContent("manageNewsContent", language = languageSelection)
       }
     }
     if (input$navbar == "adminHome") {
       if (!ui_loaded$adminHome) {
         output$adminHome_ui <- renderUI(adminLandingUI("adminHome"))
         ui_loaded$adminHome <- TRUE
-        adminLanding("adminHome")
+        adminLanding("adminHome", language = languageSelection)
       }
     }
     if (input$navbar == "manageNotifications") {
@@ -2161,14 +2179,18 @@ $(document).keyup(function(event) {
           notification_module_choices
         ))
         ui_loaded$manageNotifications <- TRUE
-        manageNotifications("manageNotifications", notification_module_choices)
+        manageNotifications(
+          "manageNotifications",
+          notification_module_choices,
+          language = languageSelection
+        )
       }
     }
     if (input$navbar == "viewFeedback") {
       if (!ui_loaded$viewFeedback) {
         output$viewFeedback_ui <- renderUI(viewFeedbackUI("viewFeedback"))
         ui_loaded$viewFeedback <- TRUE
-        viewFeedback("viewFeedback")
+        viewFeedback("viewFeedback", language = languageSelection)
       }
     }
     if (input$navbar == "changePwd") {
@@ -2182,14 +2204,14 @@ $(document).keyup(function(event) {
       if (!ui_loaded$manageUsers) {
         output$manageUsers_ui <- renderUI(manageUsersUI("manageUsers"))
         ui_loaded$manageUsers <- TRUE
-        manageUsers("manageUsers")
+        manageUsers("manageUsers", language = languageSelection)
       }
     }
     if (input$navbar == "visit") {
       if (!ui_loaded$visit) {
         output$visit_ui <- renderUI(visitUI("visit")) # Render the UI
         ui_loaded$visit <- TRUE
-        visit("visit") # Call the server
+        visit("visit", language = languageSelection) # Call the server
       }
     }
   }) # End of observeEvent for loading modules based on navbar


### PR DESCRIPTION
### Motivation

- Make it possible to show application-level notifications inside every module by rendering the existing `application_notifications_ui` banner in each module's UI area. 
- Ensure notification language selection works for each module by passing the app `languageSelection` into module server functions. 
- Include the admin landing page in the list of notification targets so admin notices can be displayed there as well.

### Description

- Inserted `uiOutput(ns("banner"))` into many module UIs (admin and client modules across continuous/discrete data, images, documents, reports, maps, FOD, WWR, etc.) to reserve space for dismissible notification banners. 
- Updated module server signatures to accept a `language` argument and added an `output$banner <- renderUI({ application_notifications_ui(...) })` block that calls `application_notifications_ui` with `ns`, `language$language`, `session$userData$AquaCache`, and a module-specific `module_id` to render notifications. 
- Updated `inst/apps/YGwater/server.R` to pass `language = languageSelection` into module server calls where modules were changed, and adjusted a few argument orders (e.g. `contPlotOld`) to match the new signatures. 
- Added `"adminHome"` to `notification_module_choices` so admin landing notifications can be targeted.

### Testing

- No automated tests were run as requested. 
- Changes were committed after updating module UIs and server wiring; runtime testing (app start / UI rendering) was not executed per the instructions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696ecc602a9c832f8b7fb2c0222a88c6)