### PR TITLE
Decouple PDF rendering from table selection in simplerIndex

### DIFF
--- a/inst/apps/YGwater/modules/admin/boreholes_wells/simplerIndex.R
+++ b/inst/apps/YGwater/modules/admin/boreholes_wells/simplerIndex.R
@@ -1248,10 +1248,16 @@ simplerIndex <- function(id, language) {
         order(assigned_flag, rv$files_df$borehole_id, decreasing = TRUE),
       ]
       if (!is.null(current_tag)) {
-        rv$display_index <- match(current_tag, rv$files_df$tag)
+        new_index <- match(current_tag, rv$files_df$tag)
+        if (!is.na(new_index)) {
+          rv$display_index <- new_index
+        }
       }
       if (!is.null(selected_tag)) {
-        rv$selected_index <- match(selected_tag, rv$files_df$tag)
+        new_index <- match(selected_tag, rv$files_df$tag)
+        if (!is.na(new_index)) {
+          rv$selected_index <- new_index
+        }
       }
     }
 
@@ -2696,6 +2702,25 @@ simplerIndex <- function(id, language) {
       {
         req(rv$files_df)
         if (nrow(rv$files_df) > 0) {
+          display_tag <- if (
+            !is.null(rv$display_index) &&
+              nrow(rv$files_df) >= rv$display_index
+          ) {
+            rv$files_df$tag[rv$display_index]
+          } else {
+            NULL
+          }
+          selected_tag <- if (
+            !is.null(rv$selected_index) &&
+              nrow(rv$files_df) >= rv$selected_index
+          ) {
+            rv$files_df$tag[rv$selected_index]
+          } else {
+            NULL
+          }
+          display_index_before <- rv$display_index
+          selected_index_before <- rv$selected_index
+
           selected_row <- if (!is.null(rv$selected_index)) {
             rv$selected_index
           } else {
@@ -2729,15 +2754,29 @@ simplerIndex <- function(id, language) {
             rv$display_index <- 1
             rv$selected_index <- NULL
           } else {
-            if (rv$display_index > nrow(rv$files_df)) {
-              rv$display_index <- nrow(rv$files_df)
+            display_index <- if (!is.null(display_tag)) {
+              match(display_tag, rv$files_df$tag)
+            } else {
+              NA_integer_
             }
-            if (
-              !is.null(rv$selected_index) &&
-                rv$selected_index > nrow(rv$files_df)
-            ) {
-              rv$selected_index <- nrow(rv$files_df)
+            if (is.na(display_index)) {
+              display_index <- min(display_index_before, nrow(rv$files_df))
             }
+            rv$display_index <- max(1, display_index)
+
+            selected_index <- if (!is.null(selected_tag)) {
+              match(selected_tag, rv$files_df$tag)
+            } else {
+              NA_integer_
+            }
+            if (is.na(selected_index)) {
+              if (!is.null(selected_index_before)) {
+                selected_index <- min(selected_index_before, nrow(rv$files_df))
+              } else {
+                selected_index <- NULL
+              }
+            }
+            rv$selected_index <- selected_index
           }
           sort_files_df()
           bump_table_version()


### PR DESCRIPTION
### Motivation
- Prevent frequent and unintended PDF re-renders and selection loops caused by table row selection driving the displayed page and instead require an explicit user action to render a page.
- Make it visually clear which page is currently shown in the center pane.

### Description
- Introduce two separate indices: `rv$display_index` (the page currently rendered) and `rv$selected_index` (the table-selected row), and migrate logic that previously used `pdf_index` to use `display_index` where appropriate (many references in `inst/apps/YGwater/modules/admin/boreholes_wells/simplerIndex.R`).
- Add a new actionButton `show_selected_pdf` and a short helper text so rendering only happens when the user clicks "Show selected page"; table selection now only updates `selected_index` and does not trigger rendering.
- Update navigation and removal logic to operate on `display_index` for the displayed page while allowing `selected_index` to drive delete/other actions when appropriate, and keep indices synchronized after sorting/removal via `sort_files_df()`.
- Update the PDF pages datatable to include a hidden `row_id` column and apply `DT::formatStyle()` to highlight the row for the currently displayed page (`rv$display_index`) with a distinct background and font style so users can see which page is shown.

### Testing
- No automated tests were executed per the repository instructions not to run R or test tooling in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69799d6c3978832f90eb46068227d20a)