### PR TITLE
Fix PDF removal index tracking in borehole admin UI

### DIFF
--- a/inst/apps/YGwater/modules/admin/boreholes_wells/simplerIndex.R
+++ b/inst/apps/YGwater/modules/admin/boreholes_wells/simplerIndex.R
@@ -1248,10 +1248,16 @@ simplerIndex <- function(id, language) {
         order(assigned_flag, rv$files_df$borehole_id, decreasing = TRUE),
       ]
       if (!is.null(current_tag)) {
-        rv$display_index <- match(current_tag, rv$files_df$tag)
+        new_index <- match(current_tag, rv$files_df$tag)
+        if (!is.na(new_index)) {
+          rv$display_index <- new_index
+        }
       }
       if (!is.null(selected_tag)) {
-        rv$selected_index <- match(selected_tag, rv$files_df$tag)
+        new_index <- match(selected_tag, rv$files_df$tag)
+        if (!is.na(new_index)) {
+          rv$selected_index <- new_index
+        }
       }
     }
 
@@ -2696,6 +2702,25 @@ simplerIndex <- function(id, language) {
       {
         req(rv$files_df)
         if (nrow(rv$files_df) > 0) {
+          display_tag <- if (
+            !is.null(rv$display_index) &&
+              nrow(rv$files_df) >= rv$display_index
+          ) {
+            rv$files_df$tag[rv$display_index]
+          } else {
+            NULL
+          }
+          selected_tag <- if (
+            !is.null(rv$selected_index) &&
+              nrow(rv$files_df) >= rv$selected_index
+          ) {
+            rv$files_df$tag[rv$selected_index]
+          } else {
+            NULL
+          }
+          display_index_before <- rv$display_index
+          selected_index_before <- rv$selected_index
+
           selected_row <- if (!is.null(rv$selected_index)) {
             rv$selected_index
           } else {
@@ -2729,15 +2754,29 @@ simplerIndex <- function(id, language) {
             rv$display_index <- 1
             rv$selected_index <- NULL
           } else {
-            if (rv$display_index > nrow(rv$files_df)) {
-              rv$display_index <- nrow(rv$files_df)
+            display_index <- if (!is.null(display_tag)) {
+              match(display_tag, rv$files_df$tag)
+            } else {
+              NA_integer_
             }
-            if (
-              !is.null(rv$selected_index) &&
-                rv$selected_index > nrow(rv$files_df)
-            ) {
-              rv$selected_index <- nrow(rv$files_df)
+            if (is.na(display_index)) {
+              display_index <- min(display_index_before, nrow(rv$files_df))
             }
+            rv$display_index <- max(1, display_index)
+
+            selected_index <- if (!is.null(selected_tag)) {
+              match(selected_tag, rv$files_df$tag)
+            } else {
+              NA_integer_
+            }
+            if (is.na(selected_index)) {
+              if (!is.null(selected_index_before)) {
+                selected_index <- min(selected_index_before, nrow(rv$files_df))
+              } else {
+                selected_index <- NULL
+              }
+            }
+            rv$selected_index <- selected_index
           }
           sort_files_df()
           bump_table_version()


### PR DESCRIPTION
### Motivation
- Deleting a PDF row that is before the currently displayed page could shift the displayed tag up by one, causing the center pane to jump to the wrong page and subsequent actions to operate on the wrong page. 
- The recent refactor that relies on stored `tag` values exposed cases where reindexing could write `NA` into `rv$display_index`/`rv$selected_index` when a tag no longer exists after a sort or deletion.

### Description
- Updated `sort_files_df` to compute `match` results into `new_index` and only assign to `rv$display_index`/`rv$selected_index` when `!is.na(new_index)`, preventing overwriting with `NA`.
- In the `remove_pdf` observer captured `display_tag` and `selected_tag` before removing the selected row, and saved the pre-deletion indices into `display_index_before`/`selected_index_before` so the current view can be preserved.
- After deleting the row, rematched `display_tag`/`selected_tag` against the updated `rv$files_df` and set `rv$display_index`/`rv$selected_index` to the matched index when present, with fallbacks that clamp to `min(previous_index, nrow(rv$files_df))` and ensure `rv$display_index >= 1` to avoid jumping to the wrong page.
- Changes are confined to `inst/apps/YGwater/modules/admin/boreholes_wells/simplerIndex.R` and maintain existing calls to `sort_files_df()` and `bump_table_version()`.

### Testing
- No automated tests were run on the modified code (per project instructions).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6979a87dcc64832f941d37f6dc114cea)