### PR TITLE
Fixed bug in creating new groups, quotes were breaking sql

### DIFF
--- a/inst/apps/YGwater/modules/admin/users/manageUsers.R
+++ b/inst/apps/YGwater/modules/admin/users/manageUsers.R
@@ -282,14 +282,8 @@ WHERE schema_name NOT LIKE 'pg_%'
                 } else {
                   sql <- sprintf(
                     "GRANT %s ON TABLE %s TO %s",
-                    DBI::dbQuoteIdentifier(
-                      session$userData$AquaCache,
-                      permission
-                    ),
-                    DBI::dbQuoteIdentifier(
-                      session$userData$AquaCache,
-                      table
-                    ),
+                    permission,
+                    table,
                     DBI::dbQuoteIdentifier(
                       session$userData$AquaCache,
                       input$group_name


### PR DESCRIPTION
Dropped calls to `dbQuoteIdentifier` around the `permission` and `table` objects in manageUsers.R.  `permission` references a reserved word and shouldn't be quoted.  While table names _can_ be quoted, in many cases throughout the app, tables are referenced in format \<schema\>.\<table\>.  Passing the string `public.locations_z` to dbQuoteIdentifier outputs `"public.locations_z"`, in which case postgres is literally looking for a table called `public.locations_z`.  

If it is important to quote the table identifiers, we could potentially split the string by ".", quote them individually then rejoin (e.g. "public"."locations_z").  I didn't implement this because I wasn't certain of the stability of this method (if we ever had a table or schema with a '.' in the name this would break), so for now I've just dropped the quotes on the table identifiers.