### PR TITLE
Fixed bug in duplication checks when uploading data

### DIFF
--- a/inst/apps/YGwater/modules/admin/continuousData/addContData.R
+++ b/inst/apps/YGwater/modules/admin/continuousData/addContData.R
@@ -379,15 +379,14 @@ addContData <- function(id, language) {
         showNotification('Empty data table!', type = 'error')
         return(FALSE)
       }
-
       # Check for duplicated rows and drop them; warn the user
-      duplicated <- duplicated(data$df)
-      if (nrow(duplicated)) {
-        data$df <- data$df[!duplicated, ]
+      duplicated_rows <- duplicated(data$df)
+      if (any(duplicated_rows)) {
+        data$df <- data$df[!duplicated_rows, ]
         showNotification(
           paste0(
             'There were ',
-            nrow(duplicated),
+            sum(duplicated_rows),
             ' duplicated (completely identical) rows. Only the first occurence of each unique row was retained'
           ),
           type = 'message',
@@ -395,7 +394,7 @@ addContData <- function(id, language) {
         )
       }
       duplicated_datetimes <- data$df$datetime[duplicated(data$df$datetime)]
-      if (length(duplicated_datetimes) < 0) {
+      if (length(duplicated_datetimes) > 0) {
         showNotification(
           paste0(
             'There is more than one datetime for ',


### PR DESCRIPTION
Fixed hard crash in an if-statement when evaluating presence of fully duplicated rows.  Crash was caused by call to `nrow()` on `duplicated` object because `duplicated` is a logical vector.  Switched if-statement to use `any()` rather than `nrow()`.

Renamed `duplicated` object to `duplicated_rows` to avoid namespace collision with `duplicated()` function. 

Reversed binary operator such that the duplicated datetimes logic will fire.