### PR TITLE
Dropped positional parameter  in call where only 15 parameters are provided

### DIFF
--- a/inst/apps/YGwater/modules/admin/continuousData/addTimeseries.R
+++ b/inst/apps/YGwater/modules/admin/continuousData/addTimeseries.R
@@ -1016,7 +1016,7 @@ addTimeseries <- function(id, language) {
               # Make a new entry to the timeseries table
               new_timeseries_id <- DBI::dbGetQuery(
                 con,
-                "INSERT INTO continuous.timeseries (location_id, sub_location_id, timezone_daily_calc, z_id, parameter_id, media_id, sensor_priority, aggregation_type_id, record_rate, default_owner, share_with, source_fx, source_fx_args, note, end_datetime) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16) RETURNING timeseries_id;",
+                "INSERT INTO continuous.timeseries (location_id, sub_location_id, timezone_daily_calc, z_id, parameter_id, media_id, sensor_priority, aggregation_type_id, record_rate, default_owner, share_with, source_fx, source_fx_args, note, end_datetime) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15) RETURNING timeseries_id;",
                 params = list(
                   as.numeric(loc),
                   ifelse(is.na(sub_loc), NA, sub_loc),


### PR DESCRIPTION
The extra positional parameter `$16` causes the following error when attempting to add a timeSeries:

`Error adding timeseries: Failed to prepare query : ERROR: INSERT has more expressions than target columns LINE 1: ...$5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16) RETUR... ^`

My assumption is that, due to only 15 R objects being passed to the `params` arg, the extra positional parameter is unnecessary.

If there **should** be 16 parameters here, don't accept this pull request, modify the SQL call and the objects passed to the `params` arg to include all necessary params.
