### PR TITLE
Added more navigation tools for grades, approvals, qualifiers.  Small modification to plot behavior.

### DIFF
--- a/inst/apps/YGwater/modules/admin/continuousData/grades_approvals_qualifiers.R
+++ b/inst/apps/YGwater/modules/admin/continuousData/grades_approvals_qualifiers.R
@@ -60,6 +60,7 @@ grades_approvals_qualifiersUI <- function(id) {
                 class = "text-muted small mt-2",
                 textOutput(ns("click_feedback"))
               ),
+              hr(),
               actionButton(ns("last_year"), label = "Most Recent Year"),
               actionButton(ns("entire_ts"), label = "Full Timeseries")
             ),


### PR DESCRIPTION
Added two action buttons to "grades, approvals, qualifiers" plot selection page:

- 'Most Recent Year': Shows the most recent year of the time series.  If the time series is less than a year, just shows entire time series and displays a notification saying so.
- 'Full Timeseries': Shows entire time series.

Based majority of logic and error handling for these action buttons on `observeEvent({})` block for `input$ts_table_rows_selected`.


Modified plotly selection graph such that axis limits are based on input to `start_dt` and `end_dt` rather than returned data. The purpose of this is such that the date range the user enters is displayed, even if `start_dt` or `end_dt` overlaps with missing data in the time series, as pictured below (note the empty space on the lefthand side of the plot):

<img width="915" height="387" alt="THIS ONE" src="https://github.com/user-attachments/assets/18f675f6-dd31-46c3-939d-682a3593c246" />
