### PR TITLE
Add two-step class mapping flow to continuous upload modal

### DIFF
--- a/inst/apps/YGwater/modules/admin/continuousData/addContData.R
+++ b/inst/apps/YGwater/modules/admin/continuousData/addContData.R
@@ -662,15 +662,15 @@ addContData <- function(id, language) {
       list(
         grade = DBI::dbGetQuery(
           session$userData$AquaCache,
-          "SELECT grade_type_id AS id, grade_type_code AS code FROM public.grade_types ORDER BY grade_type_id"
+          "SELECT grade_type_id AS id, grade_type_code AS code, grade_type_description AS description FROM public.grade_types ORDER BY grade_type_id"
         ),
         approval = DBI::dbGetQuery(
           session$userData$AquaCache,
-          "SELECT approval_type_id AS id, approval_type_code AS code FROM public.approval_types ORDER BY approval_type_id"
+          "SELECT approval_type_id AS id, approval_type_code AS code, approval_type_description AS description FROM public.approval_types ORDER BY approval_type_id"
         ),
         qualifier = DBI::dbGetQuery(
           session$userData$AquaCache,
-          "SELECT qualifier_type_id AS id, qualifier_type_code AS code FROM public.qualifier_types ORDER BY qualifier_type_id"
+          "SELECT qualifier_type_id AS id, qualifier_type_code AS code, qualifier_type_description AS description FROM public.qualifier_types ORDER BY qualifier_type_id"
         )
       )
     })
@@ -678,7 +678,11 @@ addContData <- function(id, language) {
     map_modal_state <- reactiveValues(
       step = "columns",
       pending_df = NULL,
-      class_values = list(grade = character(), approval = character(), qualifier = character())
+      class_values = list(
+        grade = character(),
+        approval = character(),
+        qualifier = character()
+      )
     )
 
     build_df_from_column_mapping <- function() {
@@ -903,7 +907,7 @@ addContData <- function(id, language) {
           db_df <- db_types[[class_name]]
           db_choices <- stats::setNames(
             as.character(db_df$id),
-            paste0(db_df$code, " (", db_df$id, ")")
+            paste0(db_df$code, ": ", db_df$description)
           )
 
           mapping_ui[[length(mapping_ui) + 1]] <- tags$h5(
@@ -919,7 +923,11 @@ addContData <- function(id, language) {
               ns(paste0("map_", class_name, "_", i)),
               paste0("Uploaded '", class_vals[[i]], "' maps to:"),
               choices = db_choices,
-              selected = ""
+              multiple = TRUE,
+              options = list(
+                maxItems = 1,
+                placeholder = "Select class to map to"
+              )
             )
           }
         }


### PR DESCRIPTION
### Motivation

- Enable users to map their uploaded grade/approval/qualifier values to the database equivalents from inside the upload modal so uploaded rows are ready for insertion.
- Only require the extra mapping step when the uploaded file contains any of the optional class columns (grade/approval/qualifier).
- Keep the existing accordion controls for adding grades/approvals/qualifiers unchanged per the request.

### Description

- Added `class_type_choices` reactive to load database choices from `public.grade_types`, `public.approval_types`, and `public.qualifier_types` for use in mapping selects. 
- Introduced `map_modal_state` (reactiveValues) and a two-step modal flow: a `columns` step where the user picks datetime/value and optional class columns, and a `class_mapping` step that appears only if any class column was selected. 
- Replaced the single static modal footer with `map_modal_body` and `map_modal_footer` UI outputs so the primary action becomes `Next` when class columns are present (otherwise `Confirm`), and the final `Confirm` is shown only on the mapping step. 
- Built mapping UI dynamically to present one `selectizeInput` per unique uploaded class label (per class type) with DB code/id choices, sanitize uploaded labels, require all visible mappings before enabling the final `Confirm`, and apply selected mappings to convert uploaded labels to DB IDs before populating `data$df`.

### Testing

- Performed static verification of the changed file and inspected the diff to confirm the new modal flow and mapping logic were added. 
- Attempted an automated smoke check using Playwright to capture a screenshot of the running app, but the app endpoint was not available so the screenshot attempt failed (`net::ERR_EMPTY_RESPONSE`).
- No R runtime or unit tests were executed in this environment per the instruction to skip running R or installing R dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699de4fd1404832fa522f04b6967359b)