### PR TITLE
Add grade/approval/qualifier range editing and preview plotting in addContData module

### DIFF
--- a/inst/apps/YGwater/modules/admin/continuousData/addContData.R
+++ b/inst/apps/YGwater/modules/admin/continuousData/addContData.R
@@ -191,6 +191,20 @@ addContDataUI <- function(id) {
           )
         ), # end delete accordion panel
 
+        # Add approvals panel
+        accordion_panel(
+          id = ns("approval_panel"),
+          title = "Add/modify approval status",
+          icon = icon("thumbs-up"),
+          div(
+            actionButton(ns("add_approval_range"), "Add approval range"),
+            actionButton(ns("edit_approval_range"), "Edit selected"),
+            actionButton(ns("delete_approval_range"), "Delete selected")
+          ),
+          DT::DTOutput(ns("approval_ranges_table")),
+          uiOutput(ns("approval_ranges_warning"))
+        ), # End approval panel
+
         # Add grade panel
         accordion_panel(
           id = ns("grade_panel"),
@@ -217,21 +231,7 @@ addContDataUI <- function(id) {
           ),
           DT::DTOutput(ns("qualifier_ranges_table")),
           uiOutput(ns("qualifier_ranges_warning"))
-        ), # End qualifiers accordion panel
-
-        # Add approvals panel
-        accordion_panel(
-          id = ns("approval_panel"),
-          title = "Add/modify approval status",
-          icon = icon("thumbs-up"),
-          div(
-            actionButton(ns("add_approval_range"), "Add approval range"),
-            actionButton(ns("edit_approval_range"), "Edit selected"),
-            actionButton(ns("delete_approval_range"), "Delete selected")
-          ),
-          DT::DTOutput(ns("approval_ranges_table")),
-          uiOutput(ns("approval_ranges_warning"))
-        ) # End approval panel
+        ) # End qualifiers accordion panel
       ), # end accordion for data manipulation options
 
       br(),
@@ -1755,6 +1755,10 @@ addContData <- function(id, language) {
         maxdt <- max(pv$new_data$datetime, na.rm = TRUE)
         type_map <- class_type_choices()
         poly_list <- list()
+        new_data_dt <- sort(unique(pv$new_data$datetime))
+        approval_y <- NULL
+        grade_y <- NULL
+        qualifier_y <- NULL
 
         add_band <- function(class_name, yset, label_prefix) {
           rr <- class_ranges[[class_name]]
@@ -1763,6 +1767,12 @@ addContData <- function(id, language) {
           edt <- parse_datetime(rr$end_datetime) - (as.numeric(input$UTC_offset) * 3600)
           rr$start_dt <- pmax(sdt, mindt)
           rr$end_dt <- pmin(edt, maxdt)
+
+          # Extend each class band to the next data point to avoid visible gaps
+          next_idx <- findInterval(rr$end_dt, new_data_dt) + 1
+          has_next <- next_idx <= length(new_data_dt)
+          rr$end_dt[has_next] <- new_data_dt[next_idx[has_next]]
+
           rr <- rr[!is.na(rr$start_dt) & !is.na(rr$end_dt) & rr$end_dt >= rr$start_dt, , drop = FALSE]
           if (nrow(rr) == 0) return(invisible(NULL))
           rr$id <- paste0(class_name, "_", seq_len(nrow(rr)))
@@ -1788,11 +1798,53 @@ addContData <- function(id, language) {
           add_band("grade", grade_y, "Grade")
         }
         if (nrow(class_ranges$qualifier) > 0) {
-          add_band("qualifier", c(0, 1, 1, 0), "Qualifier")
+          qualifier_y <- c(0, 1, 1, 0)
+          add_band("qualifier", qualifier_y, "Qualifier")
         }
 
         if (length(poly_list) > 0) {
           polygons_df <- data.table::rbindlist(poly_list, use.names = TRUE)
+          annotation_list <- list()
+          if (!is.null(approval_y)) {
+            annotation_list <- c(annotation_list, list(list(
+              x = 0,
+              y = mean(approval_y[c(1, 2)]),
+              xref = "paper",
+              yref = "y",
+              text = "Approval",
+              showarrow = FALSE,
+              xanchor = "right",
+              yanchor = "middle",
+              font = list(size = 10)
+            )))
+          }
+          if (!is.null(grade_y)) {
+            annotation_list <- c(annotation_list, list(list(
+              x = 0,
+              y = mean(grade_y[c(1, 2)]),
+              xref = "paper",
+              yref = "y",
+              text = "Grade",
+              showarrow = FALSE,
+              xanchor = "right",
+              yanchor = "middle",
+              font = list(size = 10)
+            )))
+          }
+          if (!is.null(qualifier_y)) {
+            annotation_list <- c(annotation_list, list(list(
+              x = 0,
+              y = mean(qualifier_y[c(1, 2)]),
+              xref = "paper",
+              yref = "y",
+              text = "Qualifier",
+              showarrow = FALSE,
+              xanchor = "right",
+              yanchor = "middle",
+              font = list(size = 10)
+            )))
+          }
+
           bands_plot <- plotly::plot_ly() |>
             plotly::add_polygons(
               data = polygons_df,
@@ -1810,7 +1862,8 @@ addContData <- function(id, language) {
             plotly::layout(
               yaxis = list(showticklabels = FALSE, showgrid = FALSE, zeroline = FALSE),
               xaxis = list(showgrid = FALSE, showticklabels = FALSE),
-              margin = list(t = 0, b = 20, l = 50)
+              annotations = annotation_list,
+              margin = list(t = 0, b = 20, l = 80)
             )
           plot <- plotly::subplot(plot, bands_plot, nrows = 2, shareX = TRUE, heights = c(0.8, 0.2), margin = 0.02)
         }


### PR DESCRIPTION
### Motivation
- Provide users a way to manage grades/approvals/qualifiers for uploaded continuous data without editing millions of table cells. 
- Allow previewing the in-session class ranges on the plot alongside existing DB data so users can validate class ranges visually. 
- Prevent invalid uploads by validating non-overlapping rules for grades/approvals and preventing identical overlapping qualifiers. 
- Notify users when newly-entered data or ranges have changed since the last plot refresh so they know to re-run `Refresh plot`.

### Description
- Replaced the placeholder class accordions in the UI with table-driven editors and control buttons (`Add/Edit/Delete`) and added a stale-plot warning area next to the `Refresh plot` button; changes live in `inst/apps/YGwater/modules/admin/continuousData/addContData.R` UI section. 
- Added server-side reactive stores and helpers: `class_ranges` reactiveValues, `ranges_from_table_classes()`, `validate_ranges()`, `sync_table_classes_from_ranges()` and modal-based flows to `add/edit/delete` ranges and map uploaded class-coded columns into ranges. 
- Enforced validation rules that disable upload actions while invalid (grades/approvals cannot overlap; qualifiers may overlap except when the same qualifier code overlaps), and render warning text under each ranges table via `output$*_ranges_warning`. 
- Extended the preview plotting logic to draw class bands for newly-entered ranges (colors taken from class metadata) adapted from the `plotTimeseries` approach, and implemented a plot-signature (`last_plot_signature` / `current_plot_signature`) to show a stale-plot warning until `Refresh plot` is pressed; class ranges are cleared after successful uploads. 
- Included `color_code` in the class-type metadata queries so UI/plot bands use the configured colors for grade/approval/qualifier types.

### Testing
- No automated R/Shiny tests were executed per repository/instructions to avoid running R in this environment. 
- Performed repository sanity checks by inspecting diffs and status (`git diff` / `git status`), which showed the intended modifications to `inst/apps/YGwater/modules/admin/continuousData/addContData.R`.
- Manual code-level review of the new helper functions and plot integration was performed in this environment but no runtime Shiny verification was run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699f4c012474832fb3a3308361ad8d8b)